### PR TITLE
Moved histogram quantities to the kinematics

### DIFF
--- a/dynamite/kinematics.py
+++ b/dynamite/kinematics.py
@@ -15,15 +15,15 @@ class Kinematics(data.Data):
     def __init__(self,
                  weight=None,
                  type=None,
-                 hist_vel=None,
-                 hist_sigma=None,
+                 hist_width=None,
+                 hist_center=None,
                  hist_bins=None,
                  **kwargs
                  ):
         self.weight = weight
         self.type = type
-        self.hist_vel = hist_vel
-        self.hist_sigma = hist_sigma
+        self.hist_width = hist_width
+        self.hist_center = hist_center
         self.hist_bins = hist_bins
         self.__class__.values = list(self.__dict__.keys())
         super().__init__(**kwargs)

--- a/dynamite/orblib.py
+++ b/dynamite/orblib.py
@@ -195,9 +195,9 @@ class LegacyOrbitLibrary(OrbitLibrary):
             str(i+1) + ' '*30 + \
             f'[use psf {i+1} {stars.kinematic_data[i].name}] \n'
         for i in np.arange(n_psf):
-            # apertures+= self.settings['hist_vel'] + '  ' + self.settings['hist_sigma'] + '  ' + self.settings['hist_bins'] +'             [histogram]' +'\n'
-            apertures+= stars.kinematic_data[i].hist_vel + '  ' + \
-                        stars.kinematic_data[i].hist_sigma + '  ' + \
+            # apertures+= self.settings['hist_width'] + '  ' + self.settings['hist_center'] + '  ' + self.settings['hist_bins'] +'             [histogram]' +'\n'
+            apertures+= stars.kinematic_data[i].hist_width + '  ' + \
+                        stars.kinematic_data[i].hist_center + '  ' + \
                         stars.kinematic_data[i].hist_bins + \
                         f'             [histogram {stars.kinematic_data[i].name}]\n'
 

--- a/dynamite/weight_solvers.py
+++ b/dynamite/weight_solvers.py
@@ -431,8 +431,8 @@ class NNLS(WeightSolver):
             cut[naperture_cut<1,:] = False
             # to cut an orbit, replace it's h1 by 3.0/dvhist(i)
             idx_cut = np.where(cut)
-            # v_range = float(orblib.settings['hist_vel'])
-            v_range = self.system.cmp_list[2].kinematic_data[0].hist_vel
+            # v_range = float(orblib.settings['hist_width'])
+            v_range = self.system.cmp_list[2].kinematic_data[0].hist_width
             n_bins = orblib.losvd_histograms.x.size
             dvhist = v_range/n_bins
             orb_gh[idx_cut[0], idx_cut[1], 0] = 3./dvhist

--- a/tests/reimplement_nnls_config1.yaml
+++ b/tests/reimplement_nnls_config1.yaml
@@ -100,8 +100,8 @@ system_components:
             set1:
                 weight: 1.0 # weight of kinematics data specified by name
                 type: GaussHermite # specifies which object class to create
-                hist_vel: '2719.8215332031'
-                hist_sigma: '0.0000'
+                hist_width: '2719.8215332031'
+                hist_center: '0.0000'
                 hist_bins: '203'
                 datafile: "gauss_hermite_kins.ecsv"  # both discr. & integrated
                 aperturefile: "aperture.dat" # integrated only

--- a/tests/reimplement_nnls_config2.yaml
+++ b/tests/reimplement_nnls_config2.yaml
@@ -100,8 +100,8 @@ system_components:
             set1:
                 weight: 1.0 # weight of kinematics data specified by name
                 type: GaussHermite # specifies which object class to create
-                hist_vel: '2719.8215332031'
-                hist_sigma: '0.0000'
+                hist_width: '2719.8215332031'
+                hist_center: '0.0000'
                 hist_bins: '203'
                 datafile: "gauss_hermite_kins.ecsv"  # both discr. & integrated
                 aperturefile: "aperture.dat" # integrated only

--- a/tests/test_slurm_config.yaml
+++ b/tests/test_slurm_config.yaml
@@ -100,8 +100,8 @@ system_components:
             set1:
                 weight: 1.0 # weight of kinematics data specified by name
                 type: GaussHermite # specifies which object class to create
-                hist_vel: '2719.8215332031'
-                hist_sigma: '0.0000'
+                hist_width: '2719.8215332031'
+                hist_center: '0.0000'
                 hist_bins: '203'
                 datafile: "gauss_hermite_kins.ecsv"  # both discr. & integrated
                 aperturefile: "aperture.dat" # integrated only

--- a/tests/test_validate_pqu_config.yaml
+++ b/tests/test_validate_pqu_config.yaml
@@ -100,8 +100,8 @@ system_components:
             set1:
                 weight: 1.0 # weight of kinematics data specified by name
                 type: GaussHermite # specifies which object class to create
-                hist_vel: '2719.8215332031'
-                hist_sigma: '0.0000'
+                hist_width: '2719.8215332031'
+                hist_center: '0.0000'
                 hist_bins: '203'
                 datafile: "gauss_hermite_kins.ecsv"  # both discr. & integrated
                 aperturefile: "aperture.dat" # integrated only

--- a/tests/user_test_config.yaml
+++ b/tests/user_test_config.yaml
@@ -102,8 +102,8 @@ system_components:
             set1:
                 weight: 1.0 # weight of kinematics data specified by name
                 type: GaussHermite # specifies which object class to create
-                hist_vel: '2719.8215332031'
-                hist_sigma: '0.0000'
+                hist_width: '2719.8215332031'
+                hist_center: '0.0000'
                 hist_bins: '203'
                 datafile: "gauss_hermite_kins.ecsv"  # both discr. & integrated
                 aperturefile: "aperture.dat" # integrated only

--- a/tests/user_test_config_ml.yaml
+++ b/tests/user_test_config_ml.yaml
@@ -100,8 +100,8 @@ system_components:
             kinset1:
                 weight: 1.0 # weight of kinematics data specified by name
                 type: GaussHermite # specifies which object class to create
-                hist_vel: '2719.8215332031'
-                hist_sigma: '0.0000'
+                hist_width: '2719.8215332031'
+                hist_center: '0.0000'
                 hist_bins: '203'
                 datafile: "gauss_hermite_kins.ecsv"  # both discr. & integrated
                 aperturefile: "aperture.dat" # integrated only


### PR DESCRIPTION
Let's keep this pull request open until Issue #81 is addressed adequately...

Completed so far:

- Moved histogram quantities hist_vel, hist_sigma, and hist_bins to the kinematics in the config file and made them attributes of the Kinematics class.