### PR TITLE
clean up code in `orblib.py`

### DIFF
--- a/dynamite/orblib.py
+++ b/dynamite/orblib.py
@@ -331,28 +331,36 @@ class LegacyOrbitLibrary(OrbitLibrary):
         # tubeorbits
         cmdstr_tube = 'cmd_tube_orbs'
         txt_file = open(cmdstr_tube, "w")
-        txt_file.write('#!/bin/bash' + '\n')
-        txt_file.write('touch datfil/orblib.dat.tmp datfil/orblib.dat' + '\n')
-        txt_file.write('rm -f datfil/orblib.dat.tmp datfil/orblib.dat' + '\n')
-        txt_file.write( self.legacy_directory +'/orblib < infil/orblib.in >> datfil/orblib.log' + '\n')
-        txt_file.write('touch datfil/mass_qgrid.dat datfil/mass_radmass.dat datfil/mass_aper.dat' + '\n')
-        txt_file.write('rm datfil/mass_qgrid.dat datfil/mass_radmass.dat datfil/mass_aper.dat' + '\n')
-        txt_file.write( self.legacy_directory + '/triaxmass       < infil/triaxmass.in >> datfil/triaxmass.log' + '\n')
-        txt_file.write( self.legacy_directory + '/triaxmassbin    < infil/triaxmassbin.in >> datfil/triaxmassbin.log' + '\n')
-        txt_file.write('# if the gzipped orbit library does not exist zip it' + '\n')
-        txt_file.write('test -e datfil/orblib.dat.bz2 || bzip2 -k datfil/orblib.dat' + '\n')
-        txt_file.write('rm datfil/orblib.dat' + '\n')
+        txt_file.write('#!/bin/bash\n')
+        txt_file.write('touch datfil/orblib.dat.tmp datfil/orblib.dat\n')
+        txt_file.write('rm -f datfil/orblib.dat.tmp datfil/orblib.dat\n')
+        txt_file.write(f'{self.legacy_directory}/orblib < infil/orblib.in '
+                       '>> datfil/orblib.log\n')
+        txt_file.write('touch datfil/mass_qgrid.dat datfil/mass_radmass.dat '
+                       'datfil/mass_aper.dat\n')
+        txt_file.write('rm datfil/mass_qgrid.dat datfil/mass_radmass.dat '
+                       'datfil/mass_aper.dat\n')
+        txt_file.write(f'{self.legacy_directory}/triaxmass       '
+                       '< infil/triaxmass.in >> datfil/triaxmass.log\n')
+        txt_file.write(f'{self.legacy_directory}/triaxmassbin    '
+                       '< infil/triaxmassbin.in >> datfil/triaxmassbin.log\n')
+        txt_file.write('# if the gzipped orbit library does not exist zip it\n')
+        txt_file.write('test -e datfil/orblib.dat.bz2 '
+                       '|| bzip2 -k datfil/orblib.dat\n')
+        txt_file.write('rm datfil/orblib.dat\n')
         txt_file.close()
         # boxorbits
         cmdstr_box = 'cmd_box_orbs'
         txt_file = open(cmdstr_box, "w")
-        txt_file.write('#!/bin/bash' + '\n')
-        txt_file.write('touch datfil/orblibbox.dat.tmp datfil/orblibbox.dat' + '\n')
-        txt_file.write('rm -f datfil/orblibbox.dat.tmp datfil/orblibbox.dat' + '\n')
-        txt_file.write(self.legacy_directory + '/orblib < infil/orblibbox.in >> datfil/orblibbox.log' + '\n')
-        txt_file.write('# if the gzipped orbit library does not exist zip it' + '\n')
-        txt_file.write('test -e datfil/orblibbox.dat.bz2 || bzip2 -k datfil/orblibbox.dat' + '\n')
-        txt_file.write('rm datfil/orblibbox.dat' + '\n')
+        txt_file.write('#!/bin/bash\n')
+        txt_file.write('touch datfil/orblibbox.dat.tmp datfil/orblibbox.dat\n')
+        txt_file.write('rm -f datfil/orblibbox.dat.tmp datfil/orblibbox.dat\n')
+        txt_file.write(f'{self.legacy_directory}/orblib '
+                       '< infil/orblibbox.in >> datfil/orblibbox.log\n')
+        txt_file.write('# if the gzipped orbit library does not exist zip it\n')
+        txt_file.write('test -e datfil/orblibbox.dat.bz2 '
+                       '|| bzip2 -k datfil/orblibbox.dat\n')
+        txt_file.write('rm datfil/orblibbox.dat\n')
         txt_file.close()
         # returns the name of the executables
         return cmdstr_tube, cmdstr_box


### PR DESCRIPTION
@maindlt and @sthater 

I took the opportunity to clean up some of the code in `orblib.py`. These are just cosmetic changes:
- to keep within the pep8 character per line limit,
- consistently use f-strings to write variable values to files
- remove any no-longer relevant comments

Despite being 'cosmetic' changes, as I touched quite a bit of code, please run `test_nnls` and `test_multi_nnls` check things are as expected, then merge.

Many thanks :)