### PR TITLE
chisquare plots fixed

### DIFF
--- a/dynamite/plotter.py
+++ b/dynamite/plotter.py
@@ -223,9 +223,9 @@ class Plotter():
         #chlim = np.sqrt(2 * Nobs * nGH)
         chi2pmin=np.min(val[which_chi2])
         chlim = np.sqrt(2 * Nobs * nGH)
-        chi2=val[which_chi2]
-        chi2t = chi2 - chi2pmin
-        chi2 = chi2t[np.argsort(-chi2t)]
+        chi2t = val[which_chi2] - chi2pmin
+        val.add_column(chi2t, name='chi2t')
+        val.sort(['chi2t'])
 
         #start of the plotting
 
@@ -251,19 +251,19 @@ class Plotter():
                          color='black', markersize=2)
 
                 for k in range(nf - 1, -1, -1):
-                    if chi2[k]/chlim<=3: #only significant chi2 values
+                    if val['chi2t'][k]/chlim<=3: #only significant chi2 values
 
-                        color = colormap(chi2[k]/chlim)
+                        color = colormap(val['chi2t'][k]/chlim)
                         # * 240) #colours the significant chi2
 
-                        markersize = 7-(chi2[k]/(3*chlim))
+                        markersize = 10-3*(val['chi2t'][k]/(chlim))
                         #smaller chi2 become bigger :)
 
                         plt.plot((val[nofix_name[i]])[k],
                                  (val[nofix_name[j]])[k], 'o',
                                  markersize=markersize, color=color)
 
-                    if chi2[k]==0:
+                    if val['chi2t'][k]==0:
                         plt.plot((val[nofix_name[i]])[k],
                                  (val[nofix_name[j]])[k], 'x',
                                  markersize=10, color='k')


### PR DESCRIPTION
Hello everyone, 

in this branch I have modified the ```plotter.py``` to fix the error on the sorting of the chisquare values for plotting, so that the best-fit value is plotted last (and in general lower chisquare points are plotter after higher chisquare points) and the minimum is clearly seen. This should also remove the pattern of stripes that Sabine was getting (if I remember correctly, this was happening when considering only 2 parameters). I have also slightly modified the sizes of the coloured circles, so that everything should be more clearly visible.

I have tested things locally with the "all_models" files Sabine sent me, and I got the figures you see below (compare them with those she posted in issue #152, which should be closed with this!).

Let me know if you need me to change anything else! 

![plot_2dim](https://user-images.githubusercontent.com/7985055/128886014-62b71d77-26d4-498c-bf26-eeea7ab756c0.png)
![plot_multi](https://user-images.githubusercontent.com/7985055/128886033-872767af-11e5-459a-87ea-4e3f4563c8c1.png)
