### PR TITLE
fix string formatting bug

### DIFF
--- a/dynamite/kinematics.py
+++ b/dynamite/kinematics.py
@@ -255,12 +255,12 @@ class GaussHermite(Kinematics, data.Integrated):
         dsigSym = self.data['dsigma'].data
         n_gh_col = np.full_like(velSym, n_gh)
         array_to_print = [idx, velSym, dvelSym, sigSym, dsigSym, n_gh_col]
-        fmt = '%5i %13.13s %13.13s %13.13s %13.13s %5i '
+        fmt = '%5i %13.13f %13.13f %13.13f %13.13f %5i '
         for i in range(3, n_gh+1):
             hi_Sym = self.data[f'h{i}'].data
             dhi_Sym = self.data[f'dh{i}'].data
             array_to_print += [hi_Sym, dhi_Sym]
-            fmt += '%13.13s %13.13s '
+            fmt += '%13.13f %13.13f '
         array_to_print = np.transpose(array_to_print)
         np.savetxt(filename_old_format,
                    array_to_print,


### PR DESCRIPTION
- Floats were bring improperly formatted in the `kin_data.dat` files
- e.g. '1e-04' was rendered as 9.999999 rather than 0.0001 or 1e-04
- fix: replace `s` format code with `f` in `GaussHermite.convert_to_old_format`