### PR TITLE
Fixes a bug that on rare occasion caused an error when updating the timestamp entry when continuing an aborted run

### DIFF
--- a/docs/more_info/changelog.rst
+++ b/docs/more_info/changelog.rst
@@ -4,6 +4,8 @@
 Change Log
 ****************
 
+- Bugfix: Fixed a bug that on rare occasion caused an error when updating the timestamp entry when continuing an aborted run
+
 Version: 2.0
 ================
 

--- a/dynamite/model.py
+++ b/dynamite/model.py
@@ -73,7 +73,7 @@ class AllModels(object):
         dtype = [np.float64 for n in names]
         # add the columns from legacy version
         names += ['chi2', 'kinchi2', 'time_modified']
-        dtype += [np.float64, np.float64, '<M8[ms]']
+        dtype += [np.float64, np.float64, np.object]
         # add extra columns
         names += ['orblib_done', 'weights_done', 'all_done']
         dtype += [bool, bool, bool]

--- a/dynamite/parameter_space.py
+++ b/dynamite/parameter_space.py
@@ -501,7 +501,7 @@ class ParameterGenerator(object):
         idx_start = self.par_space.n_par
         idx_end = len(self.current_models.table.colnames)
         for i in range(idx_start, idx_end):
-            if self.current_models.table.columns[i].dtype == '<M8[ms]':
+            if self.current_models.table.columns[i].name == 'time_modified':
                 # current time
                 val = np.datetime64('now', 'ms')
             elif self.current_models.table.columns[i].name == 'which_iter':


### PR DESCRIPTION
On rare occasions (seems to be connected to continuing an aborted run with zero data lines in the all_models table), an error occured connected to the timestamp entry (`ValueError: Converting an integer to a NumPy datetime requires a specified unit`). The cause is in the time unit which is not passed to the astropy table meta data. This commit fixes this bug by changing the timestamp dtype to `np.object`.

The fix is tested on my PC (test_nnls.py from scratch and adding 2 more models) and VSC4 (Sabine's script that originally crashed and test_nnls.py from scratch and adding 2 more models).

@sthater, please verify that this solves your ValueError issue
@prashjet, perhaps you can run 1-2 other little test scripts to verify it doesn't break anything...