### PR TITLE
Remove incorrect error message

### DIFF
--- a/dynamite/physical_system.py
+++ b/dynamite/physical_system.py
@@ -384,12 +384,6 @@ class VisibleComponent(Component):
                     'must be mges.MGE objects'
             self.logger.error(text)
             raise ValueError(text)
-        if len(self.mge_pot.data) != len(self.mge_lum.data):
-            text = f'{self.__class__.__name__}.mge_pot and ' \
-                   f'{self.__class__.__name__}.mge_lum ' \
-                    'must be of equal length'
-            self.logger.error(text)
-            raise ValueError(text)
 
 
 class AxisymmetricVisibleComponent(VisibleComponent):


### PR DESCRIPTION
MGE pot and MGE lum no longer need to be the same length. Remove the old 
error message which tested for this.