### PR TITLE
Remove references to deprecated "silent" option

### DIFF
--- a/dev_tests/test_slurm.py
+++ b/dev_tests/test_slurm.py
@@ -33,7 +33,7 @@ def run_user_test():
 
     # read configuration
     fname = 'test_slurm_config.yaml'
-    c = dyn.config_reader.Configuration(fname, silent=True)
+    c = dyn.config_reader.Configuration(fname)
 
     # delete previous output if available
     c.remove_existing_orblibs()

--- a/docs/tutorial_notebooks/exploring_model_output.ipynb
+++ b/docs/tutorial_notebooks/exploring_model_output.ipynb
@@ -37,7 +37,7 @@
     "import dynamite as dyn\n",
     "\n",
     "fname = 'NGC6278_config.yaml'\n",
-    "c = dyn.config_reader.Configuration(fname, silent=True)\n",
+    "c = dyn.config_reader.Configuration(fname)\n",
     "\n",
     "parset = c.parspace.get_parset()\n",
     "\n",
@@ -874,7 +874,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -888,7 +888,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.11"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,

--- a/dynamite/config_reader.py
+++ b/dynamite/config_reader.py
@@ -394,20 +394,17 @@ class Configuration(object):
                     pass
                 if value['ncpus']=='all_available':
                     value['ncpus'] = self.get_n_cpus()
-                if not silent:
-                    logger.info(f"... using {value['ncpus']} CPUs "
-                                "for orbit integration.")
+                logger.debug(f"... using {value['ncpus']} CPUs "
+                             "for orbit integration.")
                 if 'ncpus_weights' not in value:
                     value['ncpus_weights'] = value['ncpus']
                 elif value['ncpus_weights'] == 'all_available':
                     value['ncpus_weights'] = self.get_n_cpus()
-                if not silent:
-                    logger.info(f"... using {value['ncpus_weights']} CPUs "
-                                "for weight solving.")
+                logger.debug(f"... using {value['ncpus_weights']} CPUs "
+                            "for weight solving.")
                 if 'modeliterator' not in value:
                     value['modeliterator'] = 'ModelInnerIterator'
-                if not silent:
-                    logger.info(f"... using iterator {value['modeliterator']}.")
+                logger.debug(f"... using iterator {value['modeliterator']}.")
                 self.settings.add('multiprocessing_settings', value)
 
             else:


### PR DESCRIPTION
The config_reader option `silent` has been deprecated since logging was introduced. This PR removes its still remaining usage from tests, tutorials, and config_reader code. In the latter, the affected logging messages are demoted from `info` to `debug`.

Shall we eliminate `silent` altogether at a later point?