### PR TITLE
`chdir` before deleting failed models

### DIFF
--- a/dynamite/model.py
+++ b/dynamite/model.py
@@ -159,11 +159,13 @@ class AllModels(object):
                     self.logger.info('No finished model found in '
                                      f'{row["directory"]} - removing row {i}.')
         # do the deletion
+        cwd = os.getcwd()
+        os.chdir(self.config.settings.io_settings['model_directory'])
         for row in to_delete:
-            self.logger.info(f"{os.getcwd()}")
             shutil.rmtree(self.table[row]['directory'])
             self.logger.info(f"Model {row}'s directory "
                              f"{self.table[row]['directory']} removed.")
+        os.chdir(cwd)
         self.table.remove_rows(to_delete)
         if table_modified:
             self.save()


### PR DESCRIPTION
When re-starting from a failure, any model for which orblibs had not been calculated are deleted.

Problem: this was being attempted from the wrong directory.
Solution: move to the model directory before deleting, move back again once done.