### PR TITLE
Make DYNAMITE work with current Astropy release

### DIFF
--- a/dynamite/model.py
+++ b/dynamite/model.py
@@ -74,7 +74,7 @@ class AllModels(object):
         dtype = [np.float64 for n in names]
         # add the columns from legacy version
         names += ['chi2', 'kinchi2', 'time_modified']
-        dtype += [np.float64, np.float64, np.object]
+        dtype += [np.float64, np.float64, str]
         # add extra columns
         names += ['orblib_done', 'weights_done', 'all_done']
         dtype += [bool, bool, bool]
@@ -83,7 +83,7 @@ class AllModels(object):
         dtype.append(int)
         # directory will be the model directory name in the models/ directory
         names.append('directory')
-        dtype.append(np.object)
+        dtype.append('<S256') # little-endian string of max. 256 characters
         self.table = table.Table(names=names, dtype=dtype)
 
     def read_completed_model_file(self):

--- a/dynamite/model_iterator.py
+++ b/dynamite/model_iterator.py
@@ -120,7 +120,7 @@ class ModelIterator(object):
         mod = self.config.all_models.get_model_from_row(row)
         orblib = mod.get_orblib()
         weight_solver = mod.get_weights(orblib)
-        time = np.datetime64('now', 'ms')
+        time = str(np.datetime64('now', 'ms'))
         return mod.chi2, mod.kinchi2, time
 
 class ModelInnerIterator(object):
@@ -378,7 +378,7 @@ class ModelInnerIterator(object):
             else:
                 mod.chi2, mod.kinchi2 = 0, 0
         all_done = orb_done and wts_done
-        time = np.datetime64('now', 'ms')
+        time = str(np.datetime64('now', 'ms'))
         # Build and write model_done_staging.ecsv
         current_model_row = table.Table(self.all_models.table[row])
         for name, value in zip(

--- a/dynamite/model_iterator.py
+++ b/dynamite/model_iterator.py
@@ -292,7 +292,7 @@ class ModelInnerIterator(object):
         """
         iteration = self.all_models.table['which_iter'][-1]
         # new orblib model directories
-        nodir = np.dtype(self.all_models.table['directory'].dtype).type(None)
+        nodir = ''
         for row in rows_orblib:
             t = self.all_models.table[:row]
             n = np.sum((t['which_iter']==iteration) & (t['directory']!=nodir))
@@ -505,8 +505,7 @@ class SplitModelIterator(ModelInnerIterator):
                                   f'{input_list}.')
                 if len(input_list) > 0:
                     # model directory already assigned if it is a 'new' orblib
-                    no_dir = \
-                      np.dtype(self.all_models.table['directory'].dtype).type(None)
+                    no_dir = ''
                     new_dir_idx = [i for i in rows_to_do
                         if self.all_models.table['directory'][i] == no_dir]
                     if len(new_dir_idx) > 0:

--- a/dynamite/parameter_space.py
+++ b/dynamite/parameter_space.py
@@ -517,7 +517,7 @@ class ParameterGenerator(object):
                 # iteration
                 val = n_iter
             elif self.current_models.table.columns[i].name == 'directory':
-                val = None
+                val = ''
             else:
                 # empty entry for all other columns
                 dtype = self.current_models.table.columns[i].dtype

--- a/dynamite/parameter_space.py
+++ b/dynamite/parameter_space.py
@@ -512,7 +512,7 @@ class ParameterGenerator(object):
         for i in range(idx_start, idx_end):
             if self.current_models.table.columns[i].name == 'time_modified':
                 # current time
-                val = np.datetime64('now', 'ms')
+                val = str(np.datetime64('now', 'ms'))
             elif self.current_models.table.columns[i].name == 'which_iter':
                 # iteration
                 val = n_iter

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-astropy==4.2
+astropy>=5.0.4
 cvxopt>=1.2.6
 h5py>=3.1.0
 logging>=0.4.9.6


### PR DESCRIPTION
The issues:
- Newer versions of Astropy reported "Object of type datetime is not JSON serializable" in the `np.object`-typed `time_modified` column. This caused DYNAMITE to crash.
- Also, `time_modified` and `directory` entries were surrounded by multiple quotes.

This PR fixes both and implements the requirement `astropy>=5.0.4`, closing issue #214.

Successfully tested with `test_nnls.py` and both requirements `astropy==4.2` and `astropy>=5.0.4`.

Please run a few tests and if successful merge ;-)

Background:
This PR assigns the type `str` to `time_modified` in conjunction with converting the datetime object into a `str` and typing the `directory` column as a string of 256 characters maximum length (`'<S256'`). The slightly different treatment of the columns is necessary because the string representation of datetime is always of the same length, but for the directory the lengths may vary which cannot be handled by the Astropy table.