### PR TITLE
Fix for the tutorial notebook parameter_space.ipynb

### DIFF
--- a/docs/tutorial_notebooks/parameter_space.ipynb
+++ b/docs/tutorial_notebooks/parameter_space.ipynb
@@ -25,23 +25,25 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[INFO] 15:20:22 - dynamite.config_reader.Configuration - Config file NGC6278_config.yaml read.\n",
-      "[INFO] 15:20:22 - dynamite.config_reader.Configuration - io_settings...\n",
-      "[INFO] 15:20:22 - dynamite.config_reader.Configuration - system_attributes...\n",
-      "[INFO] 15:20:22 - dynamite.config_reader.Configuration - model_components...\n",
-      "[INFO] 15:20:22 - dynamite.config_reader.Configuration - system_parameters...\n",
-      "[INFO] 15:20:22 - dynamite.config_reader.Configuration - orblib_settings...\n",
-      "[INFO] 15:20:22 - dynamite.config_reader.Configuration - weight_solver_settings...\n",
-      "[INFO] 15:20:22 - dynamite.config_reader.Configuration - parameter_space_settings...\n",
-      "[INFO] 15:20:22 - dynamite.config_reader.Configuration - multiprocessing_settings...\n",
-      "[INFO] 15:20:22 - dynamite.config_reader.Configuration - ... using 4 CPUs.\n",
-      "[INFO] 15:20:22 - dynamite.config_reader.Configuration - legacy_settings...\n",
-      "[INFO] 15:20:22 - dynamite.config_reader.Configuration - System assembled\n",
-      "[INFO] 15:20:22 - dynamite.config_reader.Configuration - Configuration validated\n",
-      "[INFO] 15:20:22 - dynamite.config_reader.Configuration - Instantiated parameter space\n",
-      "[INFO] 15:20:22 - dynamite.model.AllModels - Previous models have been found: Reading NGC6278_output/all_models.ecsv into AllModels.table\n",
-      "[INFO] 15:20:23 - dynamite.config_reader.Configuration - Instantiated AllModels object\n",
-      "[INFO] 15:20:23 - dynamite.config_reader.Configuration - Config file backup: NGC6278_output/NGC6278_config_002.yaml.\n"
+      "[INFO] 21:30:53 - dynamite.config_reader.Configuration - Config file NGC6278_config.yaml read.\n",
+      "[INFO] 21:30:53 - dynamite.config_reader.Configuration - io_settings...\n",
+      "[INFO] 21:30:53 - dynamite.config_reader.Configuration - Output directory tree: NGC6278_output/.\n",
+      "[INFO] 21:30:53 - dynamite.config_reader.Configuration - system_attributes...\n",
+      "[INFO] 21:30:53 - dynamite.config_reader.Configuration - model_components...\n",
+      "[INFO] 21:30:53 - dynamite.config_reader.Configuration - system_parameters...\n",
+      "[INFO] 21:30:53 - dynamite.config_reader.Configuration - orblib_settings...\n",
+      "[INFO] 21:30:53 - dynamite.config_reader.Configuration - weight_solver_settings...\n",
+      "[INFO] 21:30:53 - dynamite.config_reader.Configuration - Will attempt to recover partially run models.\n",
+      "[INFO] 21:30:53 - dynamite.config_reader.Configuration - parameter_space_settings...\n",
+      "[INFO] 21:30:53 - dynamite.config_reader.Configuration - multiprocessing_settings...\n",
+      "[INFO] 21:30:53 - dynamite.config_reader.Configuration - ... using 4 CPUs for orbit integration.\n",
+      "[INFO] 21:30:53 - dynamite.config_reader.Configuration - ... using 4 CPUs for weight solving.\n",
+      "[INFO] 21:30:53 - dynamite.config_reader.Configuration - legacy_settings...\n",
+      "[INFO] 21:30:53 - dynamite.config_reader.Configuration - System assembled\n",
+      "[INFO] 21:30:53 - dynamite.config_reader.Configuration - Configuration validated\n",
+      "[INFO] 21:30:53 - dynamite.config_reader.Configuration - Instantiated parameter space\n",
+      "[INFO] 21:30:53 - dynamite.model.AllModels - No previous models (file NGC6278_output/all_models.ecsv) have been found: Making an empty table in AllModels.table\n",
+      "[INFO] 21:30:53 - dynamite.config_reader.Configuration - Instantiated AllModels object\n"
      ]
     }
    ],
@@ -109,7 +111,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Parameter / value :\n",
+      "Parameter / value in config file:\n",
       "   m-bh = 5.0\n",
       "   a-bh = 0.001\n",
       "   c-dh = 8.0\n",
@@ -122,9 +124,9 @@
     }
    ],
    "source": [
-    "print('Parameter / value :')\n",
+    "print('Parameter / value in config file:')\n",
     "for par in c.parspace:\n",
-    "    print(f'   {par.name} = {par.value}')"
+    "    print(f'   {par.name} = {par.raw_value}')"
    ]
   },
   {
@@ -139,11 +141,11 @@
     "```\n",
     "Logarithmic spacing can be useful for mass parameters. For other parameters (e.g. length scales) linearly spaced steps may be more appropriate. For other types of parameters (e.g. angles) a different spacing altogether may be preferable.\n",
     "\n",
-    "To handle these possibilities, we introduce the concept of ``raw`` parameter values, distinct from the values themselves. All values associated with parameter in the configuration file are given in ``raw`` units. When we step through parameter space, we take linear steps in ``raw`` values. The conversion from raw values to the parameter values is handles by the method\n",
+    "To handle these possibilities, we introduce the concept of ``raw`` parameter values, distinct from the values themselves. All values associated with parameters in the configuration file are given in ``raw`` units. When we step through parameter space, we take linear steps in ``raw`` values. The conversion from raw values to the parameter values is handled by the Parameter class and the parameter values are accessible via the\n",
     "```\n",
-    "Parameter.get_par_value_from_raw_value\n",
+    "Parameter.par_value\n",
     "```\n",
-    "So to convert the above list from raw values, we can do the following,"
+    "property. So to convert the above list from raw values, we can do the following,"
    ]
   },
   {
@@ -155,7 +157,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Parameter / value :\n",
+      "Parameter / value in linear units:\n",
       "   m-bh = 100000.0\n",
       "   a-bh = 0.001\n",
       "   c-dh = 8.0\n",
@@ -168,11 +170,9 @@
     }
    ],
    "source": [
-    "print('Parameter / value :')\n",
+    "print('Parameter / value in linear units:')\n",
     "for par in c.parspace:\n",
-    "    raw_value = par.value\n",
-    "    par_value = par.get_par_value_from_raw_value(raw_value)\n",
-    "    print(f'   {par.name} = {par_value}')"
+    "    print(f'   {par.name} = {par.par_value}')"
    ]
   },
   {
@@ -382,11 +382,18 @@
     "\n",
     ":)\n"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
This PR fixes the tutorial notebook `parameter_space.ipynb` by explaining and implementing the `Parameter.raw_value` and `Parameter.par_value` properties.

Please review the changed text & code and confirm the notebook executes as expected.