### PR TITLE
Doc fixes for 3.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,6 +11,7 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 import os
 import sys
+import datetime
 import dynamite as dyn
 sys.path.insert(0, os.path.abspath('../dynamite/'))
 
@@ -18,11 +19,10 @@ sys.path.insert(0, os.path.abspath('../dynamite/'))
 # -- Project information -----------------------------------------------------
 
 project = 'DYNAMITE'
-copyright = '2021, Stellar Dynamics Group in Vienna'
+copyright = f'2020-{datetime.date.today().year}, Stellar Dynamics Group in Vienna'
 author = 'Stellar Dynamics Group in Vienna'
 
 # The full version, including alpha/beta/rc tags
-#release = 'v1.0.0'
 release = 'v' + dyn.__version__
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,7 @@ sys.path.insert(0, os.path.abspath('../dynamite/'))
 # -- Project information -----------------------------------------------------
 
 project = 'DYNAMITE'
-copyright = f'2020-{datetime.date.today().year}, Stellar Dynamics Group in Vienna'
+copyright = f'2020-2022, Stellar Dynamics Group in Vienna'
 author = 'Stellar Dynamics Group in Vienna'
 
 # The full version, including alpha/beta/rc tags

--- a/docs/getting_started/configuration.rst
+++ b/docs/getting_started/configuration.rst
@@ -135,7 +135,7 @@ The following types of component are available, listed with their parameters:
     - ``gam``: AKA gamma, the inner logarithmic density slope, must be :math:`\leq 1`
 
 .. note::
-  currently (v2.0) there is only one combination of component types that is valid. This is to ensure compatibility with the Fortran implementation of the orbit integrator. Later implementations may offer more flexibility. The only current valid combination of components is:
+  currently, there is only one combination of component types that is valid. This is to ensure compatibility with the Fortran implementation of the orbit integrator. Later implementations may offer more flexibility. The only current valid combination of components is:
 
   - one ``Plummer`` component
       - representing the black hole

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,13 +13,13 @@ How to cite
 
 If you use DYNAMITE, please cite our `ASCL entry <http://www.ascl.net/code/v/2684>`_ using the following `BibTex citation <https://ui.adsabs.harvard.edu/abs/2020ascl.soft11007J/exportcitation>`_
 
-=======
+===================
 Orbit mirroring bug
-================
+===================
 
 `Quenneville et al. 2022 <https://iopscience.iop.org/article/10.3847/1538-4357/ac3e68>`_ reported a bug in the orbit calculation of the original `van den Bosch et al. 2008 <https://academic.oup.com/mnras/article/385/2/647/1068433>`_ code that is used in DYNAMITE. We corrected the old mirroring in DYNAMITE, starting from version 3.0.0. From this version on, the default DYNAMITE run uses the correct mirrroring. We caution the user to not use the old orbit calculation routine.
 
-In `Thater et al. 2022 <https://ucloud.univie.ac.at/index.php/s/t8atbqqJ7LW2cpH>`_, our team provides a thorough quantification of how this bug has affected the results of dynamical analyses performed with previous versions of the code. Focusing on the typical scientific applications of the Schwarzschild triaxial code, in all our tests we find that differences are negligible with respect to the statistical and systematic uncertainties. 
+In `Thater et al. 2022 <https://ucloud.univie.ac.at/index.php/s/t8atbqqJ7LW2cpH>`_, our team provides a thorough quantification of how this bug has affected the results of dynamical analyses performed with previous versions of the code. Focusing on the typical scientific applications of the Schwarzschild triaxial code, in all our tests we find that differences are negligible with respect to the statistical and systematic uncertainties.
 
 The bug occurred in the orbit calculation (legacy-fortran/orblib_f.f90), where a few velocity components needed a different sign (as reported in Table 1 of Quenneville et al. 2022). The corrected orbit calculation is found in (legacy-fortran/orblib_f_new_mirror.f90).
 

--- a/docs/more_info/changelog.rst
+++ b/docs/more_info/changelog.rst
@@ -4,6 +4,10 @@
 Change Log
 ****************
 
+
+- Improvement: update publication list
+- Bugfix: fixed wrong version number and copyright year in documentation
+
 Version: 3.0
 ================
 

--- a/docs/more_info/license.rst
+++ b/docs/more_info/license.rst
@@ -6,7 +6,7 @@ License
 
 MIT License
 
-Copyright (c) 2020, 2021 Glenn van de Ven and other contributors
+Copyright (c) 2020--2022 Glenn van de Ven and other contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/more_info/publications.rst
+++ b/docs/more_info/publications.rst
@@ -1,31 +1,31 @@
 .. _publications:
 
-************
+************************************
 Publications on the DYNAMITE methods
-************
+************************************
 
 Thater S., Jethwa P., Tahmasebzadeh B., Zhu L., den Brok M., Santucci G., Ding Y., Poci A., Lilley E., de Zeeuw P.T., Zocchi A., Maindl T.I., Rigamonti F., van de Ven G., Yang M., Fahrion K., 2022, A&A, (submitted), `On the robustness of triaxial Schwarzschild modelling: The effects of correcting the orbit mirroring <https://ucloud.univie.ac.at/index.php/s/t8atbqqJ7LW2cpH>`_
 
-Zhu L., van de Ven G., Leaman R., Grand R.J.J., Falcón-Barroso J., Jethwa P., Watkins L.L., Mao S., Poci A., McDermid R.M., Xu D., Nelson D., 2020, MNRAS, 496,1579, `Disentangling the formation history of galaxies via population-orbit superposition: method validation <https://ui.adsabs.harvard.edu/abs/2020MNRAS.496.1579Z/abstract>`_ 
+Zhu L., van de Ven G., Leaman R., Grand R.J.J., Falcón-Barroso J., Jethwa P., Watkins L.L., Mao S., Poci A., McDermid R.M., Xu D., Nelson D., 2020, MNRAS, 496,1579, `Disentangling the formation history of galaxies via population-orbit superposition: method validation <https://ui.adsabs.harvard.edu/abs/2020MNRAS.496.1579Z/abstract>`_
 
 van den Bosch R. C. E., van de Ven G., Verolme E. K., Cappellari M., de Zeeuw P. T., 2008, MNRAS, 385, 647, `Triaxial orbit based galaxy models with an application to the (apparent) decoupled core galaxy NGC 4365 <https://ui.adsabs.harvard.edu/abs/2008MNRAS.385..647V/abstract>`_
 
 
 
-************
+***************************************************************************
 Publications on the application of triaxial Schwarzschild models (DYNAMITE)
-************
+***************************************************************************
 
 
-Poci A., Smith, R.J., 2022, MNRAS, (accepted), `Comparing Lensing and Stellar Orbital Models of a Nearby Massive Strong-Lens Galaxy <https://ui.adsabs.harvard.edu/abs/2022MNRAS.512.5298P/abstract>`_ 
+Poci A., Smith, R.J., 2022, MNRAS, (accepted), `Comparing Lensing and Stellar Orbital Models of a Nearby Massive Strong-Lens Galaxy <https://ui.adsabs.harvard.edu/abs/2022MNRAS.512.5298P/abstract>`_
 
-Santucci G., Brough S., van de Sande J., McDermid R.M., van de Ven G., Zhu L., D'Eugenio F., Bland-Hawthorn J., Barsanti S., Bryant J.J., Croom S.M., Davies R.L., Green A.W., Lawrence J.S., Lorente N.P.F., Owers M.S., Poci A. Richards S.N., Thater S., Yi S., 2022, ApJ, (accepted), `The SAMI Galaxy Survey: The internal orbital structure and mass distribution of passive galaxies from triaxial orbit-superposition Schwarzschild models <https://ui.adsabs.harvard.edu/abs/2022arXiv220303648S/abstract>`_ 
+Santucci G., Brough S., van de Sande J., McDermid R.M., van de Ven G., Zhu L., D'Eugenio F., Bland-Hawthorn J., Barsanti S., Bryant J.J., Croom S.M., Davies R.L., Green A.W., Lawrence J.S., Lorente N.P.F., Owers M.S., Poci A. Richards S.N., Thater S., Yi S., 2022, ApJ, (accepted), `The SAMI Galaxy Survey: The internal orbital structure and mass distribution of passive galaxies from triaxial orbit-superposition Schwarzschild models <https://ui.adsabs.harvard.edu/abs/2022arXiv220303648S/abstract>`_
 
-den Brok M., Krajnović D., Emsellem E., Brinchmann J., Maseda M., 2021, MNRAS, 508, 4786, `Dynamical modelling of the twisted galaxy PGC 046832   <https://ui.adsabs.harvard.edu/abs/2021MNRAS.508.4786D/abstract>`_ 
+den Brok M., Krajnović D., Emsellem E., Brinchmann J., Maseda M., 2021, MNRAS, 508, 4786, `Dynamical modelling of the twisted galaxy PGC 046832   <https://ui.adsabs.harvard.edu/abs/2021MNRAS.508.4786D/abstract>`_
 
 Poci A., McDermid R.M., Lyubenova M., Zhu L., van de Ven, G., Iodice E., Coccato L., Pinna F., Corsini E.M., Falcón-Barroso J., Gadotti D.A., Grand R.J.J., Fahrion K., Martín-Navarro, I., Sarzi M., Viaene S., de Zeeuw P.T., 2021, A&A, 647, A145, `The Fornax3D project: Assembly histories of lenticular galaxies from a combined dynamical and population orbital analysis   <https://ui.adsabs.harvard.edu/abs/2021A%26A...647A.145P/abstract>`_
 
-Zhu L., van de Ven G., Leaman R., Pillepich A., Coccato L., Yuchen D., Falcón-Barroso J., Iodice E., Martín-Navarro, I., Pinna F., Corsini E.M., Gadotti D.A., Fahrion K., Lyubenova M., Saude M., McDermid R.M., Poci A., Sarzi M., de Zeeuw P.T., 2020, MNRAS, 496, 1579, `The Fornax3D project: discovery of ancient massive merger events in the Fornax cluster galaxies NGC 1380 and NGC 1427  <https://ui.adsabs.harvard.edu/abs/2022arXiv220315822Z/abstract>`_ 
+Zhu L., van de Ven G., Leaman R., Pillepich A., Coccato L., Yuchen D., Falcón-Barroso J., Iodice E., Martín-Navarro, I., Pinna F., Corsini E.M., Gadotti D.A., Fahrion K., Lyubenova M., Saude M., McDermid R.M., Poci A., Sarzi M., de Zeeuw P.T., 2020, MNRAS, 496, 1579, `The Fornax3D project: discovery of ancient massive merger events in the Fornax cluster galaxies NGC 1380 and NGC 1427  <https://ui.adsabs.harvard.edu/abs/2022arXiv220315822Z/abstract>`_
 
 Fahrion K., Lyubenova M., van de Ven G., Leaman R., Hilker M., Martín-Navarro I., Zhu L., Alfaro-Cuello M., Coccato L., Corsini E.M., Falcón-Barroso J., Iodice E., McDermid R.M., Sarzi M., de Zeeuw, P.T. 2019, A&A, 628, A92, `Constraining nuclear star cluster formation using MUSE-AO observations of the early-type galaxy FCC 47 <https://ui.adsabs.harvard.edu/abs/2019A%26A...628A..92F/abstract>`_
 
@@ -33,7 +33,7 @@ Jin Y., Zhu L., Long R.J., Shude M., Wang L., van de Ven G., 2019, MNRAS, 491, 1
 
 Jin Y., Zhu L., Long R.J., Shude M., Xu D., Li H., van de Ven G., 2019, MNRAS, 486, 4753, `Evaluating the ability of triaxial Schwarzschild modelling to estimate properties of galaxies from the Illustris simulation <https://ui.adsabs.harvard.edu/abs/2019MNRAS.486.4753J/abstract>`_
 
-Zhu L., van de Ven G., van den Bosch R., Rix H.-W., Lyubenova M., Falcón-Barroso J.,  Martig M., Mao S., Xu D., Jin Y., Obreja A., Grand R.J.J., Dutton A.A., Maccio A.V.,  Gómez F.A., Walcher J.C., García-Benito R., Zibetti S., Sánchez S.F., 2018, Nature Astronomy, 2, 233, `The stellar orbit distribution in present-day galaxies inferred from the CALIFA survey <https://ui.adsabs.harvard.edu/abs/2018NatAs...2..233Z/abstract>`_ 
+Zhu L., van de Ven G., van den Bosch R., Rix H.-W., Lyubenova M., Falcón-Barroso J.,  Martig M., Mao S., Xu D., Jin Y., Obreja A., Grand R.J.J., Dutton A.A., Maccio A.V.,  Gómez F.A., Walcher J.C., García-Benito R., Zibetti S., Sánchez S.F., 2018, Nature Astronomy, 2, 233, `The stellar orbit distribution in present-day galaxies inferred from the CALIFA survey <https://ui.adsabs.harvard.edu/abs/2018NatAs...2..233Z/abstract>`_
 
 Walsh J.L., van den Bosch R.C.E., Gebhardt K., Yıldırım A., Richstone D.O., Gültekin K., Husemann B., ApJ, 2016, 817, 2, `A 5 x 109 Msun Black Hole in NGC 1277 from Adaptive Optics Spectroscopy  <https://ui.adsabs.harvard.edu/abs/2016ApJ...817....2W/abstract>`_
 

--- a/docs/more_info/publications.rst
+++ b/docs/more_info/publications.rst
@@ -4,7 +4,7 @@
 Publications on the DYNAMITE methods
 ************************************
 
-Thater S., Jethwa P., Tahmasebzadeh B., Zhu L., den Brok M., Santucci G., Ding Y., Poci A., Lilley E., de Zeeuw P.T., Zocchi A., Maindl T.I., Rigamonti F., van de Ven G., Yang M., Fahrion K., 2022, A&A, (submitted), `On the robustness of triaxial Schwarzschild modelling: The effects of correcting the orbit mirroring <https://ucloud.univie.ac.at/index.php/s/t8atbqqJ7LW2cpH>`_
+Thater S., Jethwa P., Tahmasebzadeh B., Zhu L., den Brok M., Santucci G., Ding Y., Poci A., Lilley E., de Zeeuw P.T., Zocchi A., Maindl T.I., Rigamonti F., van de Ven G., Yang M., Fahrion K., 2022, A&A, (submitted), `On the robustness of triaxial Schwarzschild modelling: The effects of correcting the orbit mirroring <https://doi.org/10.48550/arXiv.2205.04165>`_
 
 Zhu L., van de Ven G., Leaman R., Grand R.J.J., Falcón-Barroso J., Jethwa P., Watkins L.L., Mao S., Poci A., McDermid R.M., Xu D., Nelson D., 2020, MNRAS, 496,1579, `Disentangling the formation history of galaxies via population-orbit superposition: method validation <https://ui.adsabs.harvard.edu/abs/2020MNRAS.496.1579Z/abstract>`_
 
@@ -17,9 +17,9 @@ Publications on the application of triaxial Schwarzschild models (DYNAMITE)
 ***************************************************************************
 
 
-Poci A., Smith, R.J., 2022, MNRAS, (accepted), `Comparing Lensing and Stellar Orbital Models of a Nearby Massive Strong-Lens Galaxy <https://ui.adsabs.harvard.edu/abs/2022MNRAS.512.5298P/abstract>`_
+Poci A., Smith, R.J., 2022, MNRAS, 512, 5298, `Comparing Lensing and Stellar Orbital Models of a Nearby Massive Strong-Lens Galaxy <https://ui.adsabs.harvard.edu/abs/2022MNRAS.512.5298P/abstract>`_
 
-Santucci G., Brough S., van de Sande J., McDermid R.M., van de Ven G., Zhu L., D'Eugenio F., Bland-Hawthorn J., Barsanti S., Bryant J.J., Croom S.M., Davies R.L., Green A.W., Lawrence J.S., Lorente N.P.F., Owers M.S., Poci A. Richards S.N., Thater S., Yi S., 2022, ApJ, (accepted), `The SAMI Galaxy Survey: The internal orbital structure and mass distribution of passive galaxies from triaxial orbit-superposition Schwarzschild models <https://ui.adsabs.harvard.edu/abs/2022arXiv220303648S/abstract>`_
+Santucci G., Brough S., van de Sande J., McDermid R.M., van de Ven G., Zhu L., D'Eugenio F., Bland-Hawthorn J., Barsanti S., Bryant J.J., Croom S.M., Davies R.L., Green A.W., Lawrence J.S., Lorente N.P.F., Owers M.S., Poci A. Richards S.N., Thater S., Yi S., 2022, ApJ, 930, 153, `The SAMI Galaxy Survey: The internal orbital structure and mass distribution of passive galaxies from triaxial orbit-superposition Schwarzschild models <https://ui.adsabs.harvard.edu/abs/2022ApJ...930..153S/abstract>`_
 
 den Brok M., Krajnović D., Emsellem E., Brinchmann J., Maseda M., 2021, MNRAS, 508, 4786, `Dynamical modelling of the twisted galaxy PGC 046832   <https://ui.adsabs.harvard.edu/abs/2021MNRAS.508.4786D/abstract>`_
 

--- a/dynamite/config_reader.py
+++ b/dynamite/config_reader.py
@@ -726,8 +726,8 @@ class Configuration(object):
         dest_directory : str, mandatory
             The directory the config file will be copied to.
         clean : bool, optional
-            If True, all *.yaml files in dest_directory will be deleted before
-            copying. Default is True.
+            If True, all `*`.yaml files in dest_directory will be deleted
+            before copying. Default is True.
         """
         if dest_directory[-1] != '/':
             dest_directory += '/'


### PR DESCRIPTION
Hi @ejlilley,

could you please pull this commit and re-build the docs with DYNAMITE 3.0 installed (`make html` in the docs folder). The correct version will then be included in the documentation and it can be published on the website. Closes #226.

More improvements:

- The year in the copyright message will now be `2020-<current year>`.
- Explicit current version text has been removed from `configuration.rst`.
- Fixed some Sphinx warnings (deprecation messages still occur).

If happy with the docs, please also merge this PR :-)

Thanks and cheers,
Thomas