### PR TITLE
Fixes a bug that may occur in all parameter generators in certain cases

### DIFF
--- a/docs/more_info/changelog.rst
+++ b/docs/more_info/changelog.rst
@@ -4,6 +4,7 @@
 Change Log
 ****************
 
+- Bugfix: Fixed a bug that may cause a crash in case a parameter does not have a minstep value
 - Improvement: DYNAMITE will catch and correct the erroneous parameter generator setting minstep>step by setting minstep=step for non-fixed component parameters
 - Bugfix: Fixed a bug that may occur in the parameter generators (ensures that DYNAMITE creates all possible models)
 

--- a/docs/more_info/changelog.rst
+++ b/docs/more_info/changelog.rst
@@ -4,6 +4,8 @@
 Change Log
 ****************
 
+- Bugfix: Fixed a bug that - in rare cases - may occur in the parameter generators
+
 Version: 3.0
 ================
 

--- a/docs/more_info/changelog.rst
+++ b/docs/more_info/changelog.rst
@@ -4,7 +4,8 @@
 Change Log
 ****************
 
-- Bugfix: Fixed a bug that - in rare cases - may occur in the parameter generators
+- Improvement: DYNAMITE will catch and correct the erroneous parameter generator setting minstep>step by setting minstep=step for non-fixed component parameters
+- Bugfix: Fixed a bug that may occur in the parameter generators (ensures that DYNAMITE creates all possible models)
 
 Version: 3.0
 ================

--- a/dynamite/parameter_space.py
+++ b/dynamite/parameter_space.py
@@ -458,9 +458,9 @@ class ParameterGenerator(object):
         else:
             this_iter = np.max(self.current_models.table['which_iter']) + 1
         # check whether we need to do anything in the first place...
+        newmodels = 0
         if not self.status['stop']:
             self.specific_generate_method(**kw_specific_generate_method)
-            newmodels = 0
             # Add new models to current_models.table
             for m in self.model_list:
                 if self._is_newmodel(m, eps=1e-10):

--- a/dynamite/parameter_space.py
+++ b/dynamite/parameter_space.py
@@ -671,7 +671,7 @@ class LegacyGridSearch(ParameterGenerator):
                     # Explicitly set minstep=0 to allow arbitrarily
                     # small steps, not recommended.
                     self.minstep.append(settings['minstep'] \
-                        if 'minstep' in settings else self.step)
+                        if 'minstep' in settings else settings['step'])
                 else:
                     self.step.append(None)
                     self.minstep.append(None)
@@ -745,7 +745,7 @@ class LegacyGridSearch(ParameterGenerator):
                     for s in [-1, 1]:
                         new_raw_value = np.clip(raw_center + s*step, lo, hi)
                         if abs(new_raw_value-par.raw_value) \
-                           > minstep - sys.float_info.epsilon:
+                           >= minstep - sys.float_info.epsilon:
                             self.new_parset[paridx].raw_value = new_raw_value
                             if self._is_newmodel(self.new_parset, eps=1e-10):
                                 self.model_list.append\
@@ -827,7 +827,7 @@ class GridWalk(ParameterGenerator):
                     self.step.append(settings['step'])
                     # use 'minstep' value if present, otherwise use 'step'
                     self.minstep.append(settings['minstep'] \
-                        if 'minstep' in settings else self.step)
+                        if 'minstep' in settings else settings['step'])
                 else:
                     self.step.append(None)
                     self.minstep.append(None)
@@ -937,7 +937,7 @@ class GridWalk(ParameterGenerator):
             raw_values = []
             # start with lo...
             delta = center[paridx] - self.clip(center[paridx] - step, lo, hi)
-            if abs(delta) > minstep - sys.float_info.epsilon:
+            if abs(delta) >= minstep - sys.float_info.epsilon:
                 raw_values.append(self.clip(center[paridx] - step, lo, hi))
             # now mid... tol(erance) is necessary in case minstep < eps
             if len(raw_values) > 0:
@@ -951,7 +951,7 @@ class GridWalk(ParameterGenerator):
                 raw_values.append(self.clip(center[paridx], lo, hi))
             # and now hi...
             delta = self.clip(center[paridx] + step, lo, hi) - center[paridx]
-            if abs(delta) > minstep - sys.float_info.epsilon:
+            if abs(delta) >= minstep - sys.float_info.epsilon:
                 tol = abs(self.clip(center[paridx]+step,lo,hi)-raw_values[-1])
                 if abs(raw_values[-1]) > eps:
                     tol /= abs(raw_values[-1])
@@ -1051,7 +1051,7 @@ class FullGrid(ParameterGenerator):
                     self.step.append(settings['step'])
                     # use 'minstep' value if present, otherwise use 'step'
                     self.minstep.append(settings['minstep'] \
-                        if 'minstep' in settings else self.step)
+                        if 'minstep' in settings else settings['step'])
                 else:
                     self.step.append(None)
                     self.minstep.append(None)
@@ -1169,8 +1169,8 @@ class FullGrid(ParameterGenerator):
             # start with lo...
             while raw_value >= lo:
                 raw_new = self.clip(raw_value-step, lo, hi)
-                if abs(raw_value-raw_new) > max(minstep,eps) \
-                                            - sys.float_info.epsilon:
+                if abs(raw_value-raw_new) >= max(minstep,eps) \
+                                             - sys.float_info.epsilon:
                     raw_values.append(raw_new)
                 else:
                     break
@@ -1179,8 +1179,8 @@ class FullGrid(ParameterGenerator):
             raw_value = center[paridx]
             while raw_value <= hi:
                 raw_new = self.clip(raw_value+step, lo, hi)
-                if abs(raw_value-raw_new) > max(minstep,eps) \
-                                            - sys.float_info.epsilon:
+                if abs(raw_value-raw_new) >= max(minstep,eps) \
+                                             - sys.float_info.epsilon:
                     raw_values.append(raw_new)
                 else:
                     break

--- a/dynamite/parameter_space.py
+++ b/dynamite/parameter_space.py
@@ -1,3 +1,4 @@
+import sys
 import copy
 import logging
 import numpy as np
@@ -743,7 +744,8 @@ class LegacyGridSearch(ParameterGenerator):
                     raw_center = self.new_parset[paridx].raw_value
                     for s in [-1, 1]:
                         new_raw_value = np.clip(raw_center + s*step, lo, hi)
-                        if abs(new_raw_value-par.raw_value) >= minstep:
+                        if abs(new_raw_value-par.raw_value) \
+                           > minstep - sys.float_info.epsilon:
                             self.new_parset[paridx].raw_value = new_raw_value
                             if self._is_newmodel(self.new_parset, eps=1e-10):
                                 self.model_list.append\
@@ -935,7 +937,7 @@ class GridWalk(ParameterGenerator):
             raw_values = []
             # start with lo...
             delta = center[paridx] - self.clip(center[paridx] - step, lo, hi)
-            if abs(delta) >= minstep:
+            if abs(delta) > minstep - sys.float_info.epsilon:
                 raw_values.append(self.clip(center[paridx] - step, lo, hi))
             # now mid... tol(erance) is necessary in case minstep < eps
             if len(raw_values) > 0:
@@ -949,7 +951,7 @@ class GridWalk(ParameterGenerator):
                 raw_values.append(self.clip(center[paridx], lo, hi))
             # and now hi...
             delta = self.clip(center[paridx] + step, lo, hi) - center[paridx]
-            if abs(delta) >= minstep:
+            if abs(delta) > minstep - sys.float_info.epsilon:
                 tol = abs(self.clip(center[paridx]+step,lo,hi)-raw_values[-1])
                 if abs(raw_values[-1]) > eps:
                     tol /= abs(raw_values[-1])
@@ -1167,7 +1169,8 @@ class FullGrid(ParameterGenerator):
             # start with lo...
             while raw_value >= lo:
                 raw_new = self.clip(raw_value-step, lo, hi)
-                if abs(raw_value-raw_new) >= max(minstep,eps):
+                if abs(raw_value-raw_new) > max(minstep,eps) \
+                                            - sys.float_info.epsilon:
                     raw_values.append(raw_new)
                 else:
                     break
@@ -1176,7 +1179,8 @@ class FullGrid(ParameterGenerator):
             raw_value = center[paridx]
             while raw_value <= hi:
                 raw_new = self.clip(raw_value+step, lo, hi)
-                if abs(raw_value-raw_new) >= max(minstep,eps):
+                if abs(raw_value-raw_new) > max(minstep,eps) \
+                                            - sys.float_info.epsilon:
                     raw_values.append(raw_new)
                 else:
                     break

--- a/dynamite/physical_system.py
+++ b/dynamite/physical_system.py
@@ -264,8 +264,9 @@ class Component(object):
         """
         Validate the component
 
-        Ensure it has the required attributes and parameters.
-        Additionally, the sformat strings for the parameters are set.
+        Ensure it has the required attributes and parameters. Also validates
+        the parameter generator settings' minstep value for non-fixed
+        parameters.
 
         Parameters
         ----------
@@ -301,6 +302,16 @@ class Component(object):
                    f'{par}, not {pars}.'
             self.logger.error(text)
             raise ValueError(text)
+
+        for p in [p for p in self.parameters
+                  if not p.fixed and 'minstep' in p.par_generator_settings]:
+            generator_settings = p.par_generator_settings
+            if generator_settings['minstep'] > generator_settings['step']:
+                text = f"{self.__class__.__name__} parameter {p.name}'s " \
+                       "parameter generator settings have minstep > step, " \
+                       f"setting minstep=step={generator_settings['step']}."
+                self.logger.warning(text)
+                generator_settings['minstep'] = generator_settings['step']
 
     def validate_parset(self, par):
         """
@@ -446,8 +457,8 @@ class TriaxialVisibleComponent(VisibleComponent):
         """
         Validate the TriaxialVisibleComponent
 
-        In addition to validating parameter names and setting their sformat
-        strings, also set self.qobs (minimal flattening from mge data)
+        Validates parameter names and sets self.qobs
+        (minimal flattening from mge data).
 
         Returns
         -------

--- a/dynamite/physical_system.py
+++ b/dynamite/physical_system.py
@@ -58,7 +58,9 @@ class System(object):
 
         Ensures the System has the required attributes: at least one component,
         no duplicate component names, and the ml parameter, and that the
-        sformat string for the ml parameter is set.
+        sformat string for the ml parameter is set. Also validates
+        the parameter generator settings' minstep value for ml if it is a
+        non-fixed parameter.
 
         Raises
         ------
@@ -85,7 +87,16 @@ class System(object):
             text = 'System needs ml as its sole parameter'
             self.logger.error(text)
             raise ValueError(text)
-        self.parameters[0].update(sformat = '01.2f') # sformat of ml parameter
+        ml = self.parameters[0]
+        ml.update(sformat = '01.2f') # sformat of ml parameter
+        if not ml.fixed and 'minstep' in ml.par_generator_settings:
+            generator_settings = ml.par_generator_settings
+            if generator_settings['minstep'] > generator_settings['step']:
+                text = f"{self.__class__.__name__} parameter {ml.name}'s " \
+                       "parameter generator settings have minstep > step, " \
+                       f"setting minstep=step={generator_settings['step']}."
+                self.logger.warning(text)
+                generator_settings['minstep'] = generator_settings['step']
 
     def validate_parset(self, par):
         """

--- a/dynamite/physical_system.py
+++ b/dynamite/physical_system.py
@@ -516,15 +516,17 @@ class TriaxialVisibleComponent(VisibleComponent):
         if u>1:
             theta = phi = psi = np.nan
             self.logger.debug(f'DEPROJ FAIL: u>1')
+        if np.isclose(u,p):
+            u=p
         # Check for possible triaxial deprojection (v. d. Bosch 2004,
         # triaxpotent.f90 and v. d. Bosch et al. 2008, MNRAS 385, 2, 647)
         str = f'{q} <= {p} <= {1}, ' \
-              f'{max((q/self.qobs,p))} <= {u} <= {min((p/self.qobs),1)}, ' \
+              f'{max((q/self.qobs,p))} < {u} <= {min((p/self.qobs),1)}, ' \
               f'q\'={self.qobs}'
         # 0<=t<=1, t = (1-p2)/(1-q2) and p,q>0 is the same as 0<q<=p<=1 and q<1
         t = (1-p2)/(1-q2)
         if not (0 <= t <= 1) or \
-           not (max((q/self.qobs,p)) <= u <= min((p/self.qobs),1)) :
+           not (max((q/self.qobs,p)) < u <= min((p/self.qobs),1)) :
             theta = phi = psi = np.nan
             self.logger.debug(f'DEPROJ FAIL: {str}')
         else:
@@ -919,7 +921,7 @@ class TriaxialCoredLogPotential(DarkComponent):
         phi = np.arccos(np.sqrt(xx/zz))
         m = (zz-yy)/(zz-xx)
         Menc = r*vc**2/G * (1 - rc**2*r/np.sqrt((r**2+rc**2)*(r**2/p**2+rc**2)*(r**2/q**2+rc**2))*(zz-xx)**(-0.5)*special.ellipkinc(phi,m))
-        
+
 
 class GeneralisedNFW(DarkComponent):
     """A GeneralisedNFW halo


### PR DESCRIPTION
Fixes a bug that may occur in all parameter generators in case that for at least one parameter:

**Either**
`minstep=step` and a rounding error occurs when comparing the actual parameter delta to `minstep`

**and/or**
at the edge of the parameter interval (a) the parameter is clipped to `lo` and/or `hi` _and_ (b) the parameter delta=`minstep` _and_ (c) a rounding error occurs when comparing the actual parameter delta to `minstep`.

The fix involves replacing expressions similar to `abs(raw_value-raw_new) >= max(minstep,eps)` by the safer variant `abs(raw_value-raw_new) > max(minstep,eps) - sys.float_info.epsilon`.

Closes #230

Tested with Sabine's galaxy and `FullGrid` and `LegacyGridSearch`, but a small orbit library.

Sabine, it would be great if you tested this with your galaxy under realistic conditions.