### PR TITLE
Combine first iterations

### DIFF
--- a/dev_tests/user_test_config_ml.yaml
+++ b/dev_tests/user_test_config_ml.yaml
@@ -181,7 +181,7 @@ parameter_space_settings:
     stopping_criteria:
         min_delta_chi2_abs : 0.5  # absolute "optimality tolerance"
         #min_delta_chi2_rel : 0.05 # relative "optimality tolerance"
-        n_max_mods : 5 #3
+        n_max_mods : 3
         n_max_iter : 10
 
 legacy_settings:

--- a/dev_tests/user_test_config_ml.yaml
+++ b/dev_tests/user_test_config_ml.yaml
@@ -181,7 +181,7 @@ parameter_space_settings:
     stopping_criteria:
         min_delta_chi2_abs : 0.5  # absolute "optimality tolerance"
         #min_delta_chi2_rel : 0.05 # relative "optimality tolerance"
-        n_max_mods : 3
+        n_max_mods : 5 #3
         n_max_iter : 10
 
 legacy_settings:

--- a/docs/more_info/changelog.rst
+++ b/docs/more_info/changelog.rst
@@ -5,6 +5,7 @@ Change Log
 ****************
 
 
+- Improvement: now the models of the first two iterations are computed together, better utilizing parallel computing
 - Improvement: update publication list
 - Bugfix: fixed wrong version number and copyright year in documentation
 

--- a/dynamite/model_iterator.py
+++ b/dynamite/model_iterator.py
@@ -296,10 +296,10 @@ class ModelInnerIterator(object):
         None.
 
         """
-        iteration = self.all_models.table['which_iter'][-1]
         # new orblib model directories
         nodir = ''
         for row in rows_orblib:
+            iteration = self.all_models.table[row]['which_iter']
             t = self.all_models.table[:row]
             n = np.sum((t['which_iter']==iteration) & (t['directory']!=nodir))
             orblib_dir = f'orblib_{iteration:03d}_{n:03d}'

--- a/dynamite/model_iterator.py
+++ b/dynamite/model_iterator.py
@@ -62,27 +62,33 @@ class ModelIterator(object):
             do_dummy_run=do_dummy_run,
             dummy_chi2_function=dummy_chi2_function)
         if len(config.all_models.table)>0:
-            previous_iter = np.max(config.all_models.table['which_iter'])+1
+            previous_iter = np.max(config.all_models.table['which_iter'])
         else:
-            previous_iter = 0
+            previous_iter = -1
         status = {}
         status['stop'] = False
         # if configured, re-calculate weights for past models where weight
         # calculation failed
         if config.settings.weight_solver_settings['reattempt_failures']:
             self.reattempt_failed_weights()
-        for iteration in range(stopping_crit['n_max_iter']):
-            total_iter_count = previous_iter + iteration
+        iteration = 1
+        while iteration <= stopping_crit['n_max_iter']:
+            total_iter = previous_iter + iteration
             n_models_done = np.sum(config.all_models.table['all_done'])
             if n_models_done >= stopping_crit['n_max_mods']:
                 status['n_max_mods_reached'] = True
                 status['stop'] = True
             if status['stop'] is True:
-                self.logger.info(f'Stopping at iteration {total_iter_count}')
+                self.logger.info(f'Stopping at iteration {total_iter}')
                 self.logger.debug(status)
                 break
-            self.logger.info(f'{par_generator_type}: "iteration '
-                        f'{total_iter_count}"')
+            if total_iter > 0:
+                self.logger.info(f'{par_generator_type}: iteration '
+                                 f'{total_iter}')
+                iteration += 1
+            else:
+                self.logger.info(f'{par_generator_type}: iterations 0 and 1')
+                iteration += 2
             status = model_inner_iterator.run_iteration()
             if plots:
                 the_plotter.make_chi2_vs_model_id_plot()

--- a/dynamite/parameter_space.py
+++ b/dynamite/parameter_space.py
@@ -479,8 +479,8 @@ class ParameterGenerator(object):
             self.logger.info(f'{self.name} added {newmodels} new model(s) '
                              f'out of {len(self.model_list)}')
         self.status['n_new_models'] = newmodels
-        last_iter_check = True if newmodels == 0 else False
-        self.status['last_iter_added_no_new_models'] = last_iter_check
+        last_iter_no_new_models = True if newmodels == 0 else False
+        self.status['last_iter_added_no_new_models'] = last_iter_no_new_models
         if newmodels == 0:
             self.status['stop'] = True
         return self.status

--- a/dynamite/parameter_space.py
+++ b/dynamite/parameter_space.py
@@ -469,20 +469,19 @@ class ParameterGenerator(object):
                          f'{len(self.model_list)}')
         # combine first two iterations by calling the generator again...
         if this_iter==0 and newmodels>0:
-            this_iter = np.max(self.current_models.table['which_iter']) + 1
+            newmodels0 = newmodels
+            this_iter += 1
             self.specific_generate_method(**kw_specific_generate_method)
             # Add new models to current_models.table
             for m in self.model_list:
                 if self._is_newmodel(m, eps=1e-10):
                     self.add_model(m, n_iter=this_iter)
                     newmodels += 1
-            self.logger.info(f'{self.name} added {newmodels} new model(s) '
-                             f'out of {len(self.model_list)}')
+            self.logger.info(f'{self.name} added {newmodels-newmodels0} new '
+                             f'model(s) out of {len(self.model_list)}')
         self.status['n_new_models'] = newmodels
-        last_iter_no_new_models = True if newmodels == 0 else False
-        self.status['last_iter_added_no_new_models'] = last_iter_no_new_models
-        if newmodels == 0:
-            self.status['stop'] = True
+        self.status['last_iter_added_no_new_models'] = newmodels==0
+        self.status['stop'] = newmodels==0
         return self.status
 
     def add_model(self, model=None, n_iter=0):

--- a/dynamite/parameter_space.py
+++ b/dynamite/parameter_space.py
@@ -467,6 +467,17 @@ class ParameterGenerator(object):
                     newmodels += 1
         self.logger.info(f'{self.name} added {newmodels} new model(s) out of '
                          f'{len(self.model_list)}')
+        # combine first two iterations by calling the generator again...
+        if this_iter==0 and newmodels>0:
+            this_iter = np.max(self.current_models.table['which_iter']) + 1
+            self.specific_generate_method(**kw_specific_generate_method)
+            # Add new models to current_models.table
+            for m in self.model_list:
+                if self._is_newmodel(m, eps=1e-10):
+                    self.add_model(m, n_iter=this_iter)
+                    newmodels += 1
+            self.logger.info(f'{self.name} added {newmodels} new model(s) '
+                             f'out of {len(self.model_list)}')
         self.status['n_new_models'] = newmodels
         last_iter_check = True if newmodels == 0 else False
         self.status['last_iter_added_no_new_models'] = last_iter_check


### PR DESCRIPTION
Creating the model in iteration 0 (the "first" model) will be done together with creating the models in iteration 1. Thereby the first orbit library and weight calculation will span several models, which better utilizes parallel computing.

Tested with `test_nnls.py` (different `n_max_mods` settings) so far.

Closes #218.