### PR TITLE
reattempt_failures does no longer result in an error if the orblib directory does not exist or multiple to-delete models share the same orblib

### DIFF
--- a/docs/more_info/changelog.rst
+++ b/docs/more_info/changelog.rst
@@ -4,6 +4,7 @@
 Change Log
 ****************
 
+- Bugfix: reattempt_failures does no longer result in an error if multiple to-delete models share the same orblib
 - Improvement: made DYNAMITE compatible with more Linux distributions
 - Improvement: update publication list
 - Bugfix: fixed wrong version number and copyright year in documentation

--- a/docs/more_info/changelog.rst
+++ b/docs/more_info/changelog.rst
@@ -4,7 +4,7 @@
 Change Log
 ****************
 
-- Bugfix: reattempt_failures does no longer result in an error if multiple to-delete models share the same orblib
+- Bugfix: reattempt_failures will no longer result in an error if multiple to-delete models share the same orblib or the orblib directory does not exist
 - Improvement: made DYNAMITE compatible with more Linux distributions
 - Improvement: update publication list
 - Bugfix: fixed wrong version number and copyright year in documentation


### PR DESCRIPTION
When restarting a run with `reattempt_failures: True`, models without an orblib get deleted from disk and the all_models table. Due to a bug, this resulted in an error if multiple models shared the same orblib. This PR fixes this by explicitly removing the unique `orblib_xxx_yyy` directories.

Tested with `test_nnls.py` and several reattempt_failures and provoked error settings. Please test with a realistic galaxy...