### PR TITLE
Avoid log conflicts when multiple DYNAMITE jobs share one directory

### DIFF
--- a/dev_tests/test_nnls.py
+++ b/dev_tests/test_nnls.py
@@ -32,7 +32,9 @@ def run_user_test(make_comp=False):
     else:
         file_dir = None
     fname = 'user_test_config_ml.yaml'
-    c = dyn.config_reader.Configuration(fname, reset_logging=True,
+    c = dyn.config_reader.Configuration(fname,
+                                        reset_logging=True,
+                                        user_logfile='test_nnls',
                                         reset_existing_output=True)
 
     # delete previous output if available

--- a/docs/getting_started/code_overview.rst
+++ b/docs/getting_started/code_overview.rst
@@ -159,7 +159,7 @@ To make plots, you can use the Plotter object:
 
   p = dyn.plotting.Plotter(config=c) # make the plotter object
 
-Here we propose a few examples of the plots that can be done with this object. First, you can generate maps of the surface brightness, mean line-of-sight velocity, velocity dispersion, and higher order Gauss–Hermite moments. The figure produced will show the maps relative to the data in the first row, those relative to the best-fit model in the second row and residuals in the third row; it can be obtained by using:
+Here we propose a few examples of the plots that can be done with this object. First, you can generate maps of the surface brightness, mean line-of-sight velocity, velocity dispersion, and higher order Gauss-Hermite moments. The figure produced will show the maps relative to the data in the first row, those relative to the best-fit model in the second row and residuals in the third row; it can be obtained by using:
 
 .. code-block:: python
 
@@ -277,7 +277,7 @@ If you don't want to think about logging, you can activate the DYNAMITE standard
 .. code-block:: python
 
   import dynamite as dyn
-  c = dyn.config_reader.Configuration('config_file.yaml’, reset_logging=True)
+  c = dyn.config_reader.Configuration('config_file.yaml', reset_logging=True)
 
 This will write logging messages of at least level ``INFO`` to the console and messages of at least level ``DEBUG`` to the log-file ``dynamite.log``. The levels, in increasing level of detail, are ``CRITICAL``, ``ERROR``, ``WARNING``, ``INFO``, ``DEBUG`` (currently, DYNAMITE does not use ``CRITICAL``).
 If you (optionally) wish to control the verbosity of the logging output, do not use ``reset_logging=True`` but add the following lines near the top of the main script,
@@ -291,3 +291,5 @@ If you (optionally) wish to control the verbosity of the logging output, do not 
                         logfile_level=logging.DEBUG)
 
 then you change the name of the log-file, and the level of logging output sent to the console and to the logfile. The values shown above are the defaults.
+
+By default, the logging output is recorded in the file ``dynamite.log``, but you can also specify a different file name by using the parameter ``user_logfile`` (in ``Configuration``) or ``logfile`` (in ``DynamiteLogging``). These parameters can take, as values: a string indicating your desired name for the logfile (``.log`` will be appended to the string you provide), ``False`` (which will create a UTC-timestamped logfile ``dynamiteYYMMDD-HHMMSSuuuuuu.log``), or ``None`` (which will **not** create a logfile). This option can be useful especially if you are launching multiple DYNAMITE runs from the same directory, because otherwise the logging from all the runs will be written in the same ``dynamite.log`` file.

--- a/docs/more_info/changelog.rst
+++ b/docs/more_info/changelog.rst
@@ -4,6 +4,7 @@
 Change Log
 ****************
 
+- Improvement: standard log file names are now unique by including a timestamp, avoiding log conflicts with multiple DYNAMITE runs in the same directory
 - Bugfix: reattempt_failures will no longer result in an error if multiple to-delete models share the same orblib or the orblib directory does not exist
 - Improvement: made DYNAMITE compatible with more Linux distributions
 - Improvement: update publication list

--- a/docs/more_info/changelog.rst
+++ b/docs/more_info/changelog.rst
@@ -4,7 +4,7 @@
 Change Log
 ****************
 
-- Improvement: standard log file names are now unique by including a timestamp, avoiding log conflicts with multiple DYNAMITE runs in the same directory
+- Improvement: when instantiating the Configuration object, the user can now specify the name of the logfile (several options), avoiding log conflicts with multiple DYNAMITE runs in the same directory
 - Bugfix: reattempt_failures will no longer result in an error if multiple to-delete models share the same orblib or the orblib directory does not exist
 - Improvement: made DYNAMITE compatible with more Linux distributions
 - Improvement: update publication list

--- a/dynamite/config_reader.py
+++ b/dynamite/config_reader.py
@@ -124,6 +124,14 @@ class Configuration(object):
     reset_logging : bool
         if False: use the calling application's logging settings
         if True: set logging to Dynamite defaults
+    user_logfile : str or None or False
+        Name of the logfile (``.log`` will be appended).
+        Special values: ``user_logfile=None`` will not create a logfile.
+        ``user_logfile=False`` will create a UTC-timestamped logfile
+        ``dynamiteYYMMDD-HHMMSSuuuuuu.log``.
+        Will be ignored if ``reset_logging=False``.
+        The default is ``user_logfile='dynamite'``.
+
     reset_existing_output : bool
         if False: do not touch existing data in the output directory tree
         if True: rebuild the output directory tree and delete existing data
@@ -148,10 +156,14 @@ class Configuration(object):
     thresh_chi2_abs = 'threshold_del_chi2_abs'
     thresh_chi2_scaled = 'threshold_del_chi2_as_frac_of_sqrt2nobs'
 
-    def __init__(self, filename=None, silent=None, reset_logging=False,
+    def __init__(self,
+                 filename=None,
+                 silent=None,
+                 reset_logging=False,
+                 user_logfile='dynamite',
                  reset_existing_output=False):
         if reset_logging is True:
-            DynamiteLogging()
+            DynamiteLogging(logfile=user_logfile)
             self.logger = logging.getLogger(f'{__name__}.{__class__.__name__}')
             self.logger.debug('Logging reset to Dynamite defaults')
         else:
@@ -971,9 +983,12 @@ class DynamiteLogging(object):
 
     Parameters
     ----------
-    logfile : str, optional
-        Name of the logfile, logfile=None will not create a logfile.
-        The default is the UTC-timestamped ``dynamiteYYMMDD-HHMMSSuuuuuu.log``.
+    logfile : str or None or False, optional
+        Name of the logfile (``.log`` will be appended).
+        Special values: ``logfile=None`` will not create a logfile.
+        ``logfile=False`` will create a UTC-timestamped logfile
+        ``dynamiteYYMMDD-HHMMSSuuuuuu.log``.
+        The default is ``logfile='dynamite'``.
     console_level : int, optional
         Logfile logging level. The default is logging.INFO.
     logfile_level : int, optional
@@ -984,14 +999,15 @@ class DynamiteLogging(object):
         Format string for logfile logging. The default is set in the code.
 
     """
-    def __init__(self, logfile=False, console_level=logging.INFO,
-                                      logfile_level=logging.DEBUG,
-                                      console_formatter = None,
-                                      logfile_formatter = None):
+    def __init__(self, logfile='dynamite', console_level=logging.INFO,
+                                           logfile_level=logging.DEBUG,
+                                           console_formatter = None,
+                                           logfile_formatter = None):
         if logfile is False: # as opposed to None...
             logfile = 'dynamite' +\
-                      datetime.datetime.utcnow().strftime('%Y%m%d-%H%M%S%f') +\
-                      '.log'
+                      datetime.datetime.utcnow().strftime('%Y%m%d-%H%M%S%f')
+        if type(logfile) is str:
+            logfile += '.log'
         logging.shutdown()
         importlib.reload(logging)
         logger = logging.getLogger()       # create logger

--- a/dynamite/config_reader.py
+++ b/dynamite/config_reader.py
@@ -7,6 +7,7 @@ import math
 import logging
 import importlib
 import yaml
+import datetime
 
 import dynamite as dyn
 from dynamite import physical_system as physys
@@ -964,15 +965,15 @@ class DynamiteLogging(object):
 
     -   log to the console with logging level INFO, messages include the
         level, timestamp, class name, and message text
-    -   create a dynamite.log file with logging level DEBUG, messages
-        include the level, timestamp, class name,
-        filename:method:line number, and message text
+    -   create a log file with logging level DEBUG, messages include the
+        level, timestamp, class name, filename:method:line number,
+        and message text
 
     Parameters
     ----------
     logfile : str, optional
         Name of the logfile, logfile=None will not create a logfile.
-        The default is 'dynamite.log'.
+        The default is the UTC-timestamped ``dynamiteYYMMDD-HHMMSSuuuuuu.log``.
     console_level : int, optional
         Logfile logging level. The default is logging.INFO.
     logfile_level : int, optional
@@ -983,10 +984,14 @@ class DynamiteLogging(object):
         Format string for logfile logging. The default is set in the code.
 
     """
-    def __init__(self, logfile='dynamite.log', console_level=logging.INFO,
-                                               logfile_level=logging.DEBUG,
-                                               console_formatter = None,
-                                               logfile_formatter = None):
+    def __init__(self, logfile=False, console_level=logging.INFO,
+                                      logfile_level=logging.DEBUG,
+                                      console_formatter = None,
+                                      logfile_formatter = None):
+        if logfile is False: # as opposed to None...
+            logfile = 'dynamite' +\
+                      datetime.datetime.utcnow().strftime('%Y%m%d-%H%M%S%f') +\
+                      '.log'
         logging.shutdown()
         importlib.reload(logging)
         logger = logging.getLogger()       # create logger

--- a/dynamite/parameter_space.py
+++ b/dynamite/parameter_space.py
@@ -512,7 +512,7 @@ class ParameterGenerator(object):
         for i in range(idx_start, idx_end):
             if self.current_models.table.columns[i].name == 'time_modified':
                 # current time
-                val = str(np.datetime64('now', 'ms'))
+                val = str(np.datetime64('now', 's'))
             elif self.current_models.table.columns[i].name == 'which_iter':
                 # iteration
                 val = n_iter


### PR DESCRIPTION
Hello @sthater,

following up on your recent issues with reattempt_failures: as a short-term solution to the problem of distorted log files caused by multiple simultaneous DYNAMITE runs started in the same directory, this PR assigns a unique name to the logs by including a timestamp. This will make debugging based on the detailed logs much easier.

Two little features are in this PR:

- The standard name of the DYNAMITE logfile includes a timestamp and is unique now. Therefore, it is safe to execute multiple DYNAMITE runs from the same directory without distorting the logfile.

- As np.datetime64('now','ms') does not return fractional seconds, timestamps in the all_models table will no longer display fractions of a second.

Please have a look and if possible adopt the changes in `DynamiteLogging` for easier debugging of future runs ;-)

Cheers,
Thomas