### PR TITLE
Added cmasher to the list of required packages.

### DIFF
--- a/docs/more_info/changelog.rst
+++ b/docs/more_info/changelog.rst
@@ -4,6 +4,7 @@
 Change Log
 ****************
 
+- Bugfix: included cmasher in the list of required packages
 - Bugfix: reattempt_failures will no longer result in an error if multiple to-delete models share the same orblib or the orblib directory does not exist
 - Improvement: made DYNAMITE compatible with more Linux distributions
 - Improvement: update publication list

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ plotbin>=3.1.3
 PyYAML>=5.4.1
 scipy>=1.6.0
 vorbin>=3.1.4
+cmasher>=1.6.0


### PR DESCRIPTION
Dear @azocchi,

as it affects the plotter, I'd like to ask for your review (not hyper-urgent):

Per Giulia's comment: added `CMasher` to `requirements.txt`. I think it is a good idea to include it in the setup of DYNAMITE.

While not sure which version is required, I added `cmasher>=1.6.0` (1.6.0 is the latest version and has been released a while ago: Apr 6, 2021).

Installation tested on macOS 11.6.8, Python 3.9.13, including varying the required CMasher version (e.g., `cmasher==1.5.0`).

Please test if `setup.py` works, then I think we can merge ;-)

Thanks and cheers,
Thomas