### PR TITLE
Collect global constants' definition in one place

### DIFF
--- a/dev_tests/test_nnls.py
+++ b/dev_tests/test_nnls.py
@@ -14,13 +14,10 @@ matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 from astropy import table
 import dynamite as dyn
+import dynamite.constants as const
 
 def run_user_test(make_comp=False):
 
-    logger = logging.getLogger()
-    logger.info(f'Using DYNAMITE version: {dyn.__version__}')
-    logger.info(f'Located at: {dyn.__path__}')
-    # print to console anyway...
     print('Using DYNAMITE version:', dyn.__version__)
     print('Located at:', dyn.__path__)
 
@@ -43,6 +40,8 @@ def run_user_test(make_comp=False):
     # c.backup_config_file(keep=3, delete_other=True)
     # c.remove_existing_plots()
 
+    print(f'{const.GRAV_CONST_KM=}, {const.PARSEC_KM=}, {const.RHO_CRIT=}.')
+
     which_chi2 = c.settings.parameter_space_settings['which_chi2']
 
     plotdir = c.settings.io_settings['plot_directory']
@@ -58,13 +57,11 @@ def run_user_test(make_comp=False):
                     f"{c.settings.orblib_settings['nE']}" \
                     f"{c.settings.orblib_settings['nI2']}" \
                     f"{c.settings.orblib_settings['nI3']}.dat"
-    logger.debug(f'Comparing results to {compare_file}.')
+    print(f'Comparing results to {compare_file}.')
     # "run" the models
     t = time.perf_counter()
     smi = dyn.model_iterator.ModelIterator(c)
     delt = time.perf_counter()-t
-    logger.info(f'Computation time: {delt} seconds = {delt/60} minutes')
-    # print to console regardless of logging level
     print(f'Computation time: {delt} seconds = {delt/60} minutes')
 
     # print all model results
@@ -106,12 +103,6 @@ def run_user_test(make_comp=False):
         plt.ylabel(which_chi2)
         plt.savefig(plotfile_chi2)
 
-        logger.info(f'Look at {plotfile_ml} and {plotfile_chi2}')
-        chi2stat = ''
-        for s in chi2_compare.pformat(max_lines=-1, max_width=-1):
-            chi2stat += '\n'+s
-        logger.info(f'{which_chi2} comparison data: {chi2stat}')
-        # print to console anyway...
         print(f'Look at {plotfile_ml} and {plotfile_chi2}')
         print(f'{which_chi2} comparison data:\n')
         chi2_compare.pprint(max_lines=-1, max_width=-1)

--- a/dynamite/__init__.py
+++ b/dynamite/__init__.py
@@ -1,2 +1,2 @@
-from dynamite import data, global_vars, mges, orblib, physical_system, populations, weight_solvers, parameter_space, model, config_reader, model_iterator, kinematics, plotter, myrand
+from dynamite import constants, data, mges, orblib, physical_system, populations, weight_solvers, parameter_space, model, config_reader, model_iterator, kinematics, plotter, myrand
 from dynamite._version import __version__

--- a/dynamite/__init__.py
+++ b/dynamite/__init__.py
@@ -1,2 +1,2 @@
-from dynamite import data, orblib, physical_system, weight_solvers, parameter_space, model, config_reader, model_iterator, kinematics, plotter, myrand
+from dynamite import data, global_vars, mges, orblib, physical_system, populations, weight_solvers, parameter_space, model, config_reader, model_iterator, kinematics, plotter, myrand
 from dynamite._version import __version__

--- a/dynamite/config_reader.py
+++ b/dynamite/config_reader.py
@@ -8,8 +8,10 @@ import logging
 import importlib
 import yaml
 import datetime
+import numpy as np
 
 import dynamite as dyn
+from dynamite.global_vars import *
 from dynamite import physical_system as physys
 from dynamite import parameter_space as parspace
 from dynamite import kinematics as kinem
@@ -177,6 +179,10 @@ class Configuration(object):
 
         if silent is not None:
             self.logger.warning("'silent' option is deprecated and ignored")
+
+        self.logger.debug('Global variables: ' \
+                          f'{grav_const_km = }, {parsec_km = }, ' \
+                          f'{rho_crit = }')
 
         legacy_dir = \
             os.path.realpath(os.path.dirname(__file__)+'/../legacy_fortran')

--- a/dynamite/config_reader.py
+++ b/dynamite/config_reader.py
@@ -11,7 +11,7 @@ import datetime
 import numpy as np
 
 import dynamite as dyn
-from dynamite.global_vars import *
+from dynamite import constants as const
 from dynamite import physical_system as physys
 from dynamite import parameter_space as parspace
 from dynamite import kinematics as kinem
@@ -181,8 +181,8 @@ class Configuration(object):
             self.logger.warning("'silent' option is deprecated and ignored")
 
         self.logger.debug('Global variables: ' \
-                          f'{grav_const_km = }, {parsec_km = }, ' \
-                          f'{rho_crit = }')
+                          f'{const.GRAV_CONST_KM = }, {const.PARSEC_KM = }, ' \
+                          f'{const.RHO_CRIT = }.')
 
         legacy_dir = \
             os.path.realpath(os.path.dirname(__file__)+'/../legacy_fortran')

--- a/dynamite/constants.py
+++ b/dynamite/constants.py
@@ -1,0 +1,5 @@
+import numpy as np
+
+GRAV_CONST_KM = 6.67428e-11*1.98892e30/1e9
+PARSEC_KM = 1.4959787068e8*(648.000e3/np.pi)
+RHO_CRIT = (3.*((7.3000e-5)/PARSEC_KM)**2)/(8.*np.pi*GRAV_CONST_KM)

--- a/dynamite/global_vars.py
+++ b/dynamite/global_vars.py
@@ -1,5 +1,0 @@
-import numpy as np
-
-grav_const_km = 6.67428e-11*1.98892e30/1e9
-parsec_km = 1.4959787068e8*(648.000e3/np.pi)
-rho_crit = (3.*((7.3000e-5)/parsec_km)**2)/(8.*np.pi*grav_const_km)

--- a/dynamite/global_vars.py
+++ b/dynamite/global_vars.py
@@ -1,0 +1,5 @@
+import numpy as np
+
+grav_const_km = 6.67428e-11*1.98892e30/1e9
+parsec_km = 1.4959787068e8*(648.000e3/np.pi)
+rho_crit = (3.*((7.3000e-5)/parsec_km)**2)/(8.*np.pi*grav_const_km)

--- a/dynamite/plotter.py
+++ b/dynamite/plotter.py
@@ -14,7 +14,7 @@ from matplotlib.ticker import MaxNLocator, FixedLocator,LogLocator
 from matplotlib.ticker import NullFormatter
 import matplotlib.pyplot as plt
 from plotbin import display_pixels
-from dynamite.global_vars import *
+from dynamite import constants as const
 from dynamite import kinematics
 from dynamite import weight_solvers
 from dynamite import physical_system as physys
@@ -1004,9 +1004,9 @@ class Plotter():
         #Input parameters: NFW dark matter concentration and fraction,
         #and stellar mass
 
-        rhoc = (200./3.)*rho_crit*cc**3/(np.log(1.+cc) - cc/(1.+cc))
-        rc = (3./(800.*np.pi*rho_crit*cc**3)*dmfrac*mstars)**(1./3.)
-        darkmass = (800./3.)*np.pi*rho_crit*(rc*cc)**3
+        rhoc = (200./3.)*const.RHO_CRIT*cc**3/(np.log(1.+cc) - cc/(1.+cc))
+        rc = (3./(800.*np.pi*const.RHO_CRIT*cc**3)*dmfrac*mstars)**(1./3.)
+        darkmass = (800./3.)*np.pi*const.RHO_CRIT*(rc*cc)**3
 
         return rhoc, rc, darkmass
 

--- a/dynamite/plotter.py
+++ b/dynamite/plotter.py
@@ -14,6 +14,7 @@ from matplotlib.ticker import MaxNLocator, FixedLocator,LogLocator
 from matplotlib.ticker import NullFormatter
 import matplotlib.pyplot as plt
 from plotbin import display_pixels
+from dynamite.global_vars import *
 from dynamite import kinematics
 from dynamite import weight_solvers
 from dynamite import physical_system as physys
@@ -55,7 +56,7 @@ class Plotter():
         Parameters
         ----------
         which_chi2 : STR, optional
-            Which chi2 is used for determining the best models. If None, 
+            Which chi2 is used for determining the best models. If None,
             the setting from the configuration file will be used.
             The default is None.
         figtype : STR, optional
@@ -75,7 +76,7 @@ class Plotter():
         """
         if figtype is None:
             figtype = '.png'
-        
+
         which_chi2 = self.config.validate_chi2(which_chi2)
 
         n_models = len(self.all_models.table)
@@ -110,7 +111,7 @@ class Plotter():
         Parameters
         ----------
         which_chi2 : STR, optional
-            Which chi2 is used for determining the best models. If None, 
+            Which chi2 is used for determining the best models. If None,
             the setting from the configuration file will be used.
             The default is None.
         nexcl : integer, optional
@@ -221,7 +222,7 @@ class Plotter():
 
         size = 12+len(nofix_islog)
         fontsize = max(size-4,15)
-        
+
         fig = plt.figure(figsize=(size, size))
         for i in range(0, nnofix - 1):
             for j in range(nnofix-1, i, -1):
@@ -263,7 +264,7 @@ class Plotter():
 
                 if j==i+1:
                     ax.set_xlabel(xtit, fontsize=size)
-                    if nofix_islog[i]: 
+                    if nofix_islog[i]:
                         ax.set_xscale('log')
                         if  max(val[nofix_name[i]])/min(val[nofix_name[i]]) > 100:
                             ax.xaxis.set_major_locator(LogLocator(base=10,numticks=3))
@@ -1003,10 +1004,6 @@ class Plotter():
         #Input parameters: NFW dark matter concentration and fraction,
         #and stellar mass
 
-        grav_const_km = 6.67428e-11*1.98892e30/1e9
-        parsec_km = 1.4959787068e8*(648.000e3/np.pi)
-        rho_crit = (3.*((7.3000e-5)/parsec_km)**2)/(8.*np.pi*grav_const_km)
-
         rhoc = (200./3.)*rho_crit*cc**3/(np.log(1.+cc) - cc/(1.+cc))
         rc = (3./(800.*np.pi*rho_crit*cc**3)*dmfrac*mstars)**(1./3.)
         darkmass = (800./3.)*np.pi*rho_crit*(rc*cc)**3
@@ -1135,7 +1132,7 @@ class Plotter():
         Parameters
         ----------
         which_chi2 : STR, optional
-            Which chi2 is used for determining the best models. If None, 
+            Which chi2 is used for determining the best models. If None,
             the setting from the configuration file will be used.
             The default is None.
         Rmax_arcs : numerical value
@@ -1901,7 +1898,7 @@ class Plotter():
         Parameters
         ----------
         which_chi2 : STR, optional
-            Which chi2 is used for determining the best models. If None, 
+            Which chi2 is used for determining the best models. If None,
             the setting from the configuration file will be used.
             The default is None.
         Rmax_arcs : numerical value
@@ -2142,7 +2139,7 @@ class Plotter():
         Parameters
         ----------
         which_chi2 : STR, optional
-           Which chi2 is used for determining the best models. If None, 
+           Which chi2 is used for determining the best models. If None,
             the setting from the configuration file will be used.
             The default is None.
         Rmax_arcs : numerical value


### PR DESCRIPTION
Hello Alice and Edward,

global constants are now in all caps and collected in one file `constants.py`:

```
import numpy as np

GRAV_CONST_KM = 6.67428e-11*1.98892e30/1e9
PARSEC_KM = 1.4959787068e8*(648.000e3/np.pi)
RHO_CRIT = (3.*((7.3000e-5)/PARSEC_KM)**2)/(8.*np.pi*GRAV_CONST_KM)
```

Usage example:

```
from dynamite import constants as const
...
self.logger.debug(f'Global variables: {const.GRAV_CONST_KM = }, {const.PARSEC_KM = }, {const.RHO_CRIT = }.')
```

@azocchi: I added `from dynamite import constants as const` to `plotter.py` and used the new names once, but left other occurrences of the old constants untouched so I don't interfere with your code cleanup (e.g., `triaxreadparameters()`...). Please add the new constant names at your convenience ;-)

Feel free to add to constants.py if needed ;-)

Please have a look at this and if useful, let's merge...
Closes #249.