### PR TITLE
Add r_eff to plots

### DIFF
--- a/dev_tests/user_test_config_ml.yaml
+++ b/dev_tests/user_test_config_ml.yaml
@@ -12,6 +12,7 @@ system_attributes:
     distMPc: 39.96
     name: "NGC6278"
     position_angle: 97.69
+    r_eff: False # r_eff, will be calculated by DYNAMITE if False or missing
 
 system_components:
 

--- a/dev_tests/user_test_config_ml.yaml
+++ b/dev_tests/user_test_config_ml.yaml
@@ -12,7 +12,7 @@ system_attributes:
     distMPc: 39.96
     name: "NGC6278"
     position_angle: 97.69
-    r_eff: False # r_eff, will be calculated by DYNAMITE if False or missing
+    r_eff: False # r_eff, will be calculated if False or missing
 
 system_components:
 

--- a/docs/getting_started/configuration.rst
+++ b/docs/getting_started/configuration.rst
@@ -81,7 +81,8 @@ This section lists the following attributes of the system::
   system_attributes:
       distMPc: ...        # distance in MPc
       name:  ...          # name for your galaxy
-      position_angle:     # in degrees
+      position_angle: ... # in degrees
+      r_eff: ...          # r_eff, will be calculated if False or missing
 
 ``system_components``
 =====================

--- a/dynamite/physical_system.py
+++ b/dynamite/physical_system.py
@@ -30,6 +30,7 @@ class System(object):
         self.distMPc = None
         self.name = None
         self.position_angle = None
+        self.r_eff = None
         for component in args:
             self.add_component(component)
 
@@ -79,6 +80,11 @@ class System(object):
             text = 'System needs distMPc, name, and position_angle attributes'
             self.logger.error(text)
             raise ValueError(text)
+        if not self.r_eff:
+            self.r_eff = None
+        if self.r_eff is None:
+            self.logger.info('System attribute r_eff is None, will be '
+                             'calculated.')
         if not self.cmp_list:
             text = 'System has no components'
             self.logger.error(text)


### PR DESCRIPTION
Hi @sthater,

as discussed: in preparation of adding r_eff to plots, there is a new system attribute `r_eff`.
If not given in the config file or specified as `r_eff: False`, it is set to `None` and an info-message is written to the log.
Syntax in config file: see `user_test_config_ml.yaml`
Access in the code via the config object: `c.system.r_eff`

Cheers,
Thomas