### PR TITLE
Best models table

### DIFF
--- a/docs/more_info/changelog.rst
+++ b/docs/more_info/changelog.rst
@@ -4,6 +4,7 @@
 Change Log
 ****************
 
+- New feature: Added a new method AllModels.make_best_models_table() that creates a table of the best models (best n models or models within a chi2-threshold of the best) and saves it to disk
 - Improvement: Dynamite will no longer crash upon Legacy Fortran errors, but issue warnings and assign nan to the affected chi2 values
 - Improvement: When executing a dummy run (do_dummy_run==True), model_iterator will set both kinchi2 and kinmapchi2 to nan (instead of zero)
 - Improvement: DYNAMITE will retrofit existing all_models tables with the new column kinmapchi2 and calculate its values for existing models whenever possible

--- a/dynamite/model.py
+++ b/dynamite/model.py
@@ -560,8 +560,13 @@ class AllModels(object):
             The threshold value. Models with chi2 values differing
             from the opimum by at most delta will be returned. If None,
             delta will be ignored. The default is None.
-        filename : TYPE, optional
-            DESCRIPTION. The default is None.
+        filename : str, optional
+            File name of the best models table. The file is written into the
+            output directory specified in the config file. If None, the name
+            is the same as for the all models table but with '_best' added
+            to the base file name. If the file already exists, a warning
+            is logged, the existing file is backed up ('_backup' added),
+            and then overwritten. The default is None.
 
         Raises
         ------


### PR DESCRIPTION
Hello @gsantucci90 and @sthater,

this PR adds a new method `AllModels.make_best_models_table()` that creates a table of the best models (best n models or models within a chi2-threshold of the best) and saves it to disk.

Documentation:

```
    def make_best_models_table(self,
                               which_chi2=None,
                               n=None,
                               delta=None,
                               filename=None):
        """Make a table of the best models and save it to disk

        Parameters
        ----------
        which_chi2 : str, optional
            Which chi2 is used for determining the best models. If None, the
            setting from the configuration file will be used.
            The default is None.
        n : int, optional
            How many models to get. If None, n will be ignored.
            Default: if delta is specified, the default is none; if delta
            is None, the default is 10.
        delta : float, optional
            The threshold value. Models with chi2 values differing
            from the opimum by at most delta will be returned. If None,
            delta will be ignored. The default is None.
        filename : str, optional
            File name of the best models table. The file is written into the
            output directory specified in the config file. If None, the name
            is the same as for the all models table but with '_best' added
            to the base file name. If the file already exists, a warning
            is logged, the existing file is backed up ('_backup' added),
            and then overwritten. The default is None.

        Raises
        ------
        ValueError
            If both n and delta are specified (i.e., both are not None).

        Returns
        -------
        int
            The number of models in the best models table.

        """
```

Tested by adding the following lines to `test_nnls.py` and varying the `make_best_models_table()` parameters (after calling `ModelIterator()`):
```
n = c.all_models.make_best_models_table(n=2, filename='all_models.ecsv')
print(f'no of best models: {n}')
```

To make sure the new method behaves as expected, please test, too ;-)

Cheers,
Thomas