### PR TITLE
Staging recovery bugfix

### DIFF
--- a/docs/more_info/changelog.rst
+++ b/docs/more_info/changelog.rst
@@ -4,6 +4,7 @@
 Change Log
 ****************
 
+- Bugfix: Fixed a bug related to a nonexistent model directory if a crash occurs between the parameter generator adding a model and starting to solve it
 - Improvement: Dynamite will no longer crash upon Legacy Fortran errors, but issue warnings and assign nan to the affected chi2 values
 - Improvement: When executing a dummy run (do_dummy_run==True), model_iterator will set both kinchi2 and kinmapchi2 to nan (instead of zero)
 - Improvement: DYNAMITE will retrofit existing all_models tables with the new column kinmapchi2 and calculate its values for existing models whenever possible

--- a/dynamite/model_iterator.py
+++ b/dynamite/model_iterator.py
@@ -98,7 +98,7 @@ class ModelIterator(object):
                                                     cbar_lims='default')
                     plt.close('all') # just to make sure...
                 except ValueError:
-                    self.logger.warning(f'Iteration {total_iter_count}: '
+                    self.logger.warning(f'Iteration {total_iter}: '
                                         'plotting failed!')
 
     def reattempt_failed_weights(self):

--- a/dynamite/model_iterator.py
+++ b/dynamite/model_iterator.py
@@ -129,6 +129,7 @@ class ModelIterator(object):
     def get_missing_weights(self, row):
         self.logger.debug(f'Reattempting weight solving for model {row}.')
         mod = self.config.all_models.get_model_from_row(row)
+        mod.setup_directories()
         orblib = mod.get_orblib()
         weight_solver = mod.get_weights(orblib)
         time = str(np.datetime64('now', 'ms'))


### PR DESCRIPTION
Hi @gsantucci90,

after reproducing your error I think the problem was a nonexistent `ml`-directory due to a crash between the parameter generator adding the model and starting to solve it. Consequently, `create_fortran_input_nnls()` could not create `nn.in` because the directory did not exist.

Please try the little fix in this pull request, in my tests it fixed the issue...

Many thanks and cheers,
Thomas

Closes #258.