### PR TITLE
Bugfix for reattempt_failures=False

### DIFF
--- a/docs/more_info/changelog.rst
+++ b/docs/more_info/changelog.rst
@@ -4,6 +4,7 @@
 Change Log
 ****************
 
+- Bugfix: If reattempt_failures=False, in certain cases it could occur that orblibs of successful models were deleted
 - Bugfix: Fixed a bug related to a nonexistent model directory if a crash occurs between the parameter generator adding a model and starting to solve it
 - Improvement: Dynamite will no longer crash upon Legacy Fortran errors, but issue warnings and assign nan to the affected chi2 values
 - Improvement: When executing a dummy run (do_dummy_run==True), model_iterator will set both kinchi2 and kinmapchi2 to nan (instead of zero)

--- a/dynamite/model.py
+++ b/dynamite/model.py
@@ -169,14 +169,15 @@ class AllModels(object):
                                  [d[:d[:-1].rindex('/')+1]
                                  for d in self.table[to_delete]['directory']]
                                 )
-            self.logger.info(f'Will remove {len(dirs_to_delete)} '
+            self.logger.info(f'Will try to remove {len(dirs_to_delete)} '
                              'unique orblibs.')
             for directory in dirs_to_delete:
                 try:
                     # Only remove orblib directories that are not used by
                     # already completed models
-                    if directory in set(self.table[np.where(
-                                        self.table['all_done'])]['directory']):
+                    orblibs_keep = [d[:d[:-1].rindex('/')+1] for d in
+                     self.table[np.where(self.table['all_done'])]['directory']]
+                    if directory in set(orblibs_keep):
                         self.logger.info(f'Orblib directory {directory} in '
                                          'use by existing model - untouched.')
                     else:

--- a/dynamite/model.py
+++ b/dynamite/model.py
@@ -173,8 +173,16 @@ class AllModels(object):
                              'unique orblibs.')
             for directory in dirs_to_delete:
                 try:
-                    shutil.rmtree(directory)
-                    self.logger.info(f'Model directory {directory} removed.')
+                    # Only remove orblib directories that are not used by
+                    # already completed models
+                    if directory in set(self.table[np.where(
+                                        self.table['all_done'])]['directory']):
+                        self.logger.info(f'Orblib directory {directory} in '
+                                         'use by existing model - untouched.')
+                    else:
+                        shutil.rmtree(directory)
+                        self.logger.info(f'Orblib directory {directory} '
+                                         'removed.')
                 except:
                     self.logger.warning(f'Cannot remove orblib in {directory},'
                         ' perhaps it has already been removed before.')


### PR DESCRIPTION
If `reattempt_failures=False`, in certain cases it could occur that orblibs of successful models were deleted.