### PR TITLE
New parameter generator SpecificModels generates and runs a predefined list of models

### DIFF
--- a/dev_tests/test_nnls.py
+++ b/dev_tests/test_nnls.py
@@ -28,7 +28,8 @@ def run_user_test(make_comp=False):
             os.chdir(file_dir)
     else:
         file_dir = None
-    fname = 'user_test_config_ml.yaml'
+#    fname = 'user_test_config_ml.yaml'
+    fname = 'user_test_config_fixedvalues.yaml'
     c = dyn.config_reader.Configuration(fname,
                                         reset_logging=True,
                                         user_logfile='test_nnls',

--- a/dev_tests/user_test_config_fixedvalues.yaml
+++ b/dev_tests/user_test_config_fixedvalues.yaml
@@ -1,0 +1,210 @@
+# Example yaml configuration file for the legacy implementation
+# All relevant input is in one file with two sections: SYSTEM and SETTINGS
+
+# Start of yaml document
+---
+###############################################################################
+# SECTION 1 : SYSTEM
+# Define the physical system (e.g. the galaxy or globular cluster being )
+###############################################################################
+
+system_attributes:
+    distMPc: 39.96
+    name: "NGC6278"
+    position_angle: 97.69
+
+system_components:
+
+    bh: # black_hole
+        parameters:
+            m: # log(BHmass)
+                par_generator_settings:
+                    lo: 1.0
+                    hi: 10.0
+                    step: 1.
+                    minstep: 0.
+                    fixed_values:
+                        - 5.0
+                        - 5.5
+                fixed: True
+                value: 5.0
+                logarithmic: True
+                LaTeX: "$M_{BH}$"
+            a: # scale length
+                par_generator_settings:
+                    fixed_values:
+                        - 0.001
+                        - 0.002
+                fixed: True
+                value: 1.e-3  # dot required, renders as str '1e-3' otherwise
+                LaTeX: "$a_{BH}$"
+        type: "Plummer" # class name
+        include: True
+        contributes_to_potential: True
+
+    dh: # dark_halo
+        parameters:
+            c: # NFW Darkmatter concentration
+                par_generator_settings:
+                    lo: 2.0
+                    hi: 4.0
+                    step: 1.0
+                    minstep: 0.1
+                logarithmic: True
+                fixed: True
+                value: 3.0
+                LaTeX: "$log(C)$"
+            f: # NFW Darkmatter fraction
+                par_generator_settings:
+                    lo: 0.0
+                    hi: 2.0
+                    step: 0.5
+                    minstep: 0.1
+                logarithmic: True
+                fixed: True
+                value: 1.0
+                LaTeX: "$log(M_{200}/M_{star})$"
+        type: NFW
+        include: True
+        contributes_to_potential: True
+
+    # dh: # dark_halo
+    #     parameters:
+    #         f: # NFW Darkmatter fraction
+    #             par_generator_settings:
+    #                 lo: 0.0
+    #                 hi: 2.0
+    #                 step: 0.5
+    #                 minstep: 0.1
+    #             logarithmic: True
+    #             fixed: True
+    #             value: 1.0
+    #             LaTeX: "$log(M_{200}/M_{star})$"
+    #     type: NFW_m200_c
+    #     include: True
+    #     contributes_to_potential: True
+
+    stars:
+        parameters:
+            q: # intrinsic flattening (C/A)
+                par_generator_settings:
+                    lo: 0.05
+                    hi: 0.99
+                    step: 0.04
+                    minstep: 0.02
+                fixed: True
+                value: 0.54
+                LaTeX: "$q_{min}$"
+            p: # intrinsic B/A
+                par_generator_settings:
+                    lo: 0.99
+                    hi: 0.999
+                    step: 0.02
+                    minstep: 0.01
+                fixed: True
+                value: 0.99
+                LaTeX: "$p_{min}$"
+            u: # sigma_obs / sigma_intrinsic
+                par_generator_settings:
+                    lo: 0.95
+                    hi: 1.0
+                    step: 0.01
+                    minstep: 0.01
+                fixed: True
+                value: 0.9999
+                LaTeX: "$u_{min}$"
+        type: "TriaxialVisibleComponent" # class name
+        mge_pot: "mge.ecsv"
+        mge_lum: "mge.ecsv"
+        include: True
+        contributes_to_potential: True
+        kinematics: # optional, only specified for components with kinematics
+            kinset1:
+                weight: 1.0 # weight of kinematics data specified by name
+                type: GaussHermite # specifies which object class to create
+                hist_width: '2719.8215332031'
+                hist_center: '0.0000'
+                hist_bins: '203'
+                datafile: "gauss_hermite_kins.ecsv"  # both discr. & integrated
+                aperturefile: "aperture.dat" # integrated only
+                binfile: "bins.dat"          # integrated only
+
+system_parameters:
+    ml: # M/L
+        par_generator_settings:
+            lo: 1.
+            hi: 9.
+            step: 4.0
+            minstep: 0.5
+        fixed: False
+        value: 5.
+        LaTeX: "$Y_{r}$"
+
+###############################################################################
+# SECTION 2: SETTINGS
+# Define other settings e.g. for the orbit library and weight solver
+###############################################################################
+
+orblib_settings:
+    nE: 6
+    logrmin: -0.101275
+    logrmax: 1.99123
+    nI2: 5        # must be >= 4
+    nI3: 4
+    dithering: 1
+    #the following values should usually not be changed
+    orbital_periods: 200
+    sampling: 50000
+    starting_orbit: 1
+    number_orbits: -1 #-1 --> all orbits
+    accuracy: '1.0d-5'
+    # the following is intended for development & debugging and should be
+    # set to 0 for productive use
+    random_seed: 4242 # integer; any value <= 0 results in stochastic seed
+
+weight_solver_settings:
+    type: "LegacyWeightSolver"
+    nnls_solver: 1
+    # type: "NNLS"
+    # nnls_solver: 'scipy'
+    CRcut: True
+    regularisation: 0
+    number_GH: 4
+    GH_sys_err: '0.0 0.0 0.0 0.0 0.3 0.3 0.6 0.6'
+    lum_intr_rel_err: 0.01
+    sb_proj_rel_err: 0.02
+    reattempt_failures: True # If True, failed weight solving will be tried
+                             # again based on the existing orblibs
+
+parameter_space_settings:
+    # generator_type: "LegacyGridSearch"
+    # generator_type: "GridWalk"
+    # generator_type: "FullGrid"
+    generator_type: "SpecificModels"
+    which_chi2: "kinchi2" # "chi2", "kinchi2", or "kinmapchi2"
+    generator_settings:
+        # For LegacyGridSearch, specify ONE of the following two settings
+        #threshold_del_chi2_abs: 0.5  # absolute change in chi2 threshold
+        threshold_del_chi2_as_frac_of_sqrt2nobs: 0.1
+        SpecificModels_mode: "cartesian" # "list" or "cartesian"
+    stopping_criteria:
+        min_delta_chi2_abs : 0.5  # absolute "optimality tolerance"
+        #min_delta_chi2_rel : 0.05 # relative "optimality tolerance"
+        n_max_mods : 3
+        n_max_iter : 10
+
+legacy_settings:
+    directory: "default"
+
+io_settings: # paths can be given with or without trailing slash
+    input_directory: "NGC6278_input/"
+    output_directory: "NGC6278_output/"
+    all_models_file: "all_models.ecsv"
+
+multiprocessing_settings:
+    ncpus: 'all_available' # integer or 'all_available' for multiprocessing
+    ncpus_weights: 'all_available' # integer or 'all_available', optional, defaults to ncpus (not used by all iterators)
+    modeliterator: 'SplitModelIterator' # optional, default 'ModelInnerIterator'
+    orblibs_in_parallel: True
+
+# end

--- a/docs/more_info/changelog.rst
+++ b/docs/more_info/changelog.rst
@@ -4,6 +4,8 @@
 Change Log
 ****************
 
+
+- New feature: New parameter generator SpecificModels generates and runs a predefined list of models or models resulting from a cartesian product of parameter values
 - Bugfix: Fixed a bug related to a nonexistent model directory if a crash occurs between the parameter generator adding a model and starting to solve it
 - Improvement: Dynamite will no longer crash upon Legacy Fortran errors, but issue warnings and assign nan to the affected chi2 values
 - Improvement: When executing a dummy run (do_dummy_run==True), model_iterator will set both kinchi2 and kinmapchi2 to nan (instead of zero)

--- a/dynamite/config_reader.py
+++ b/dynamite/config_reader.py
@@ -921,7 +921,10 @@ class Configuration(object):
                     raise ValueError(text)
 
         gen_type = self.settings.parameter_space_settings["generator_type"]
-        allowed_types = ['GridWalk', 'LegacyGridSearch', 'FullGrid']
+        allowed_types = ['GridWalk',
+                         'LegacyGridSearch',
+                         'FullGrid',
+                         'SpecificModels']
         if gen_type not in allowed_types:
             text = f'Legacy mode: parameter space generator_type ' \
                    f'must be in {allowed_types}'


### PR DESCRIPTION
Hi @sthater and @gsantucci90,

Based on our conversation lat week: here is a first version of the new parameter generator `SpecificModels` which generates and runs a predefined list of models. The models can be given as a sequential list or a list of values can be given per parameter and DYNAMITE will build and solve the cartesian product of parameter value combinations.

How to use: see `test_nnls.py`/`user_test_config_fixedvalues.yaml` as an example. The following lines in the config file will create four models with` m in {5.0, 5.5}`,` a in {1e-3, 2e-3}`, and all all parameters at their `value` values. Setting `SpecificModels_mode: "list"` will create two models `m=5.0`, `a=1e-3` and `m=5.5`, `a=2e-3`.

This PR is still a draft so we can fine-tune according to your needs (also needs some more testing...)

Looking forward to discussing in one of our next meetings :-)

```
    bh: # black_hole
        parameters:
            m: # log(BHmass)
                par_generator_settings:
                    lo: 1.0
                    hi: 10.0
                    step: 1.
                    minstep: 0.
                    fixed_values:
                        - 5.0
                        - 5.5
                fixed: True
                value: 5.0
                logarithmic: True
                LaTeX: "$M_{BH}$"
            a: # scale length
                par_generator_settings:
                    fixed_values:
                        - 0.001
                        - 0.002
                fixed: True
                value: 1.e-3  # dot required, renders as str '1e-3' otherwise
                LaTeX: "$a_{BH}$"
...
parameter_space_settings:
    generator_type: "SpecificModels"
    which_chi2: "kinchi2" # "chi2", "kinchi2", or "kinmapchi2"
    generator_settings:
...
        SpecificModels_mode: "cartesian" # "list" or "cartesian"

```
Closes #261.