### PR TITLE
Removed logging from the list of requirements

### DIFF
--- a/docs/more_info/changelog.rst
+++ b/docs/more_info/changelog.rst
@@ -4,6 +4,7 @@
 Change Log
 ****************
 
+- Bugfix: removed logging from the list of requirements because it is in the Python standard library
 - New feature: added a new DYNAMITE module orbit_exploration, its first class Decompostion creates decomposition plots
 - Improvement: Changed the ml directory name format to '05.2f' so all model directory names have the same length
 - New feature: Added AllModels.remove_unused_orblibs() utility method to free up disk space

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 astropy>=5.0.4
+cmasher>=1.6.0
 cvxopt>=1.2.6
 h5py>=3.1.0
 lmfit
-logging>=0.4.9.6
 matplotlib>=3.3.4
 numpy>=1.20.1
 pafit>=2.0.7
@@ -11,4 +11,3 @@ plotbin>=3.1.3
 PyYAML>=5.4.1
 scipy>=1.6.0
 vorbin>=3.1.4
-cmasher>=1.6.0


### PR DESCRIPTION
Removed logging from the list of requirements because it is in the Python standard library.

Tested with a clean install and `test_nnls.py`.

Closes #273.