### PR TITLE
Removed orbit_exploration's dependencies on deprecated plotter methods.

### DIFF
--- a/dev_tests/test_decomp.py
+++ b/dev_tests/test_decomp.py
@@ -9,9 +9,11 @@ fname = 'user_test_config_ml.yaml'
 c = dyn.config_reader.Configuration(fname,
                                     reset_logging=True,
                                     user_logfile='test_decomp',
-                                    reset_existing_output=False)
+                                    reset_existing_output=True)
 
-decomp = dyn.orbit_exploration.Decomposition(c)
+dyn.model_iterator.ModelIterator(c) # generate models
+
+decomp = dyn.orbit_exploration.Decomposition(c) # do the decomposition
 
 for conversion in ('gh_expand_around_losvd_mean_and_std_deviation',
                    'gh_fit_with_free_v_sigma_params_fortran',

--- a/dynamite/orbit_exploration.py
+++ b/dynamite/orbit_exploration.py
@@ -3,13 +3,11 @@ import logging
 import subprocess
 import numpy as np
 import matplotlib.pyplot as plt
-#import astropy.io
 from plotbin.display_pixels import display_pixels
 from scipy.io import FortranFile
-from lmfit import minimize, Parameters
+import lmfit
 import dynamite as dyn
 from dynamite import pyfort_GaussHerm
-#from matplotlib.patches import Ellipse
 
 class Decomposition:
     def __init__(self, config=None, read_orblib='dynamite'):
@@ -31,7 +29,6 @@ class Decomposition:
         else:
             self.logger.debug('Using existing directory '
                               f'{self.results_directory}')
-        # self.plotter = dyn.plotter.Plotter(config=self.config)
         self.losvd_histograms, self.proj_mass = self.run_dec(read_orblib)
         self.logger.info('Orbits read and velocity histogram created.')
         self.comps = ['disk', 'thin_d', 'warm_d', 'bulge', 'all']
@@ -67,7 +64,8 @@ class Decomposition:
         skew=paramsin['skew'].value
         kurt=paramsin['kurt'].value
         g=(x-center)/sig
-        gaustot_gh=amp*np.exp(-.5*g**2)*(1+skew*(c1*g+c3*g**3)+ kurt*(c5+c2*g**2+c4*(g**4)))
+        gaustot_gh = amp*np.exp(-.5*g**2)*(1+skew*(c1*g+c3*g**3) +
+                                           kurt*(c5+c2*g**2+c4*(g**4)))
         return gaustot_gh
 
     def read_orbit_base(self, fileroot):
@@ -270,22 +268,28 @@ class Decomposition:
         return losvd_histograms, intrinsic_masses, n_orbs, projected_masses
 
     def gh_fit_with_free_v_sigma_params(self, vhist, b):
-        p_gh=Parameters()
-        p_gh.add('amp',value=np.max(vhist),vary=True)
-        p_gh.add('center',value=np.percentile(b, 50),min=np.min(b),max=np.max(b))
+        p_gh = lmfit.Parameters()
+        p_gh.add('amp', value=np.max(vhist), vary=True)
+        p_gh.add('center',
+                 value=np.percentile(b, 50),
+                 min=np.min(b),
+                 max=np.max(b))
         #p_gh.add('sig',value=(b[w]-np.min(b))/2,min=b[w]-np.min(b),max=np.max(b)-b[w]);
-        p_gh.add('sig',value=np.abs(np.percentile(b,68)-np.percentile(b, 50)),min=0,max=700)
-        p_gh.add('skew',value=0,vary=True,min=None,max=None)
-        p_gh.add('kurt',value=0,vary=True,min=None,max=None)
+        p_gh.add('sig',
+                 value=np.abs(np.percentile(b,68)-np.percentile(b, 50)),
+                 min=0,
+                 max=700)
+        p_gh.add('skew', value=0, vary=True, min=None, max=None)
+        p_gh.add('kurt', value=0, vary=True, min=None, max=None)
         gausserr_gh = lambda p,x,y: self.gaussfunc_gh(p,x)-y
-        fitout_gh=minimize(gausserr_gh,p_gh,args=(b,vhist))
+        fitout_gh = lmfit.minimize(gausserr_gh, p_gh, args=(b,vhist))
 
 #unused        fitted_p_gh = fitout_gh.params
-        pars_gh=[fitout_gh.params['amp'].value,
-                fitout_gh.params['center'].value,
-                fitout_gh.params['sig'].value,
-                fitout_gh.params['skew'].value,
-                fitout_gh.params['kurt'].value]
+        pars_gh = [fitout_gh.params['amp'].value,
+                   fitout_gh.params['center'].value,
+                   fitout_gh.params['sig'].value,
+                   fitout_gh.params['skew'].value,
+                   fitout_gh.params['kurt'].value]
 #unused        fit_gh=self.gaussfunc_gh(fitted_p_gh,b)
 #unused        resid_gh=fit_gh-vhist
         return pars_gh[1], pars_gh[2]
@@ -309,7 +313,7 @@ class Decomposition:
         return vmi, sgi
 
     def gh_expand_around_losvd_mean_and_std_deviation(self, orblib, nkin,xedg):
-        mod_losvd = dyn.kinematics.Histogram(y=orblib[np.newaxis,:,:], xedg=xedg)
+        mod_losvd=dyn.kinematics.Histogram(y=orblib[np.newaxis,:,:], xedg=xedg)
         mod_v = mod_losvd.get_mean()
         mod_sig = mod_losvd.get_sigma()
         return mod_v[0, nkin], mod_sig[0, nkin]
@@ -334,10 +338,10 @@ class Decomposition:
         self.logger.info(f'{losvd_orbs.shape = }.')
         for comp in self.comps:
             file=wdir+comp+'_orb_s22.out'
-            # norbout, ener, i2, i3, regul, orbtype, orbw, lcut, ntot \
-            #     = self.plotter.readorbout(file)
-            norbout = np.genfromtxt(file, skip_header=1, usecols=(0))
-            orbw = np.genfromtxt(file, skip_header=1, usecols=(6))
+            norbout, orbw = np.genfromtxt(file,
+                                          skip_header=1,
+                                          usecols=(0,6),
+                                          unpack=True)
             # norm_w=np.sum(orbw)
             #print('tot orb_weight', norm_w)
             orb_sel=norbout
@@ -438,8 +442,6 @@ class Decomposition:
             ocut = [0.8, 0.25, -0.25]  #selection in lambda_z following Santucci+22
         self.logger.info(f'cut lines are: {ocut}.')
 
-        savedir = self.results_directory #where to save the files
-
         if not xrange:
             xrange = [0.0, Rmax_arcs]
 
@@ -449,11 +451,6 @@ class Decomposition:
         file3_test = os.path.isfile(file3)
         if not file3_test:
             file3= '%s' % file2
-
-        # mgepar, distance, th_view, ph_view, psi_view, ml, bhmass,softlen, \
-        #     nre, lrmin, lrmax, nrth, nrrad, ndither, vv1_1, vv1_2,dm1,dm2, \
-        #     conversion_factor,grav_const_km,parsec_km, rho_crit \
-            # = self.plotter.triaxreadparameters(w_dir=self.model.directory_noml)
 
         nre = self.config.settings.orblib_settings['nE']
         nrth = self.config.settings.orblib_settings['nI2']
@@ -467,24 +464,17 @@ class Decomposition:
 #unused        nrow = norb
         ncol = int(ndither ** 3)
         #print('norb', norb)
-        # orbclass1 = self.plotter.readorbclass(file=file2, nrow=norb, ncol=ndither ** 3)
-        # orbclass2 = self.plotter.readorbclass(file=file3, nrow=norb, ncol=ndither ** 3)
         orbclass1 = np.genfromtxt(file2).T
         orbclass1 = orbclass1.reshape((5,ncol,norb), order='F')
         orbclass2 = np.genfromtxt(file3).T
         orbclass2 = orbclass1.reshape((5,ncol,norb), order='F')
 
         #print('norb, ndither', np.max(norb), ndither)
-        # norbout, ener, i2, i3, regul, orbtype, orbw, lcut, ntot \
-        #     = self.plotter.readorbout(filename=file4)
-        norbout = np.genfromtxt(file4, skip_header=1, usecols=(0))
-        ener = np.genfromtxt(file4, skip_header=1, usecols=(1))
-        i2 = np.genfromtxt(file4, skip_header=1, usecols=(2))
-        i3 = np.genfromtxt(file4, skip_header=1, usecols=(3))
-        regul = np.genfromtxt(file4, skip_header=1, usecols=(4))
-        orbtype = np.genfromtxt(file4, skip_header=1, usecols=(5))
-        orbw = np.genfromtxt(file4, skip_header=1, usecols=(6))
-        lcut = np.genfromtxt(file4, skip_header=1, usecols=(7))
+        norbout, ener, i2, i3, regul, orbtype, orbw, lcut = \
+            np.genfromtxt(file4,
+                          skip_header=1,
+                          usecols=(0,1,2,3,4,5,6,7),
+                          unpack=True)
 
         #print('ener, i2, i3', np.max(ener), np.max(i2), np.max(i3))
         #print('Maxmin and Minimum(ener)', np.max(ener), np.min(ener))
@@ -521,15 +511,11 @@ class Decomposition:
         if np.sum(np.sum(lz[:, k], axis=0) / (ndither ** 3) * orbw[k]) < 0:
             lz *= -1.0
 
-
         lzm_sign= np.sum(lz, axis=0) / ndither ** 3
 #unused        lxm_sign= np.sum(lx, axis=0) / ndither ** 3
         #print("check 2 - sign", lzm_sign, lxm_sign)
 
         self.logger.info('**Create nn_orb.out for different bulk of orbits**')
-
-        # norbout, ener, i2, i3, regul, orbtype, orbw, lcut, ntot \
-        #     = self.plotter.readorbout(filename=file4)
 
         self.logger.info(f'#orbs: {len(norbout)}.')
         ### COLD COMPONENT
@@ -546,7 +532,7 @@ class Decomposition:
             nohlz=np.ravel(np.where((lzm_sign) < ocut[0]))
         orbw_hlz[nohlz] = -999
 
-        with open(savedir + 'thin_d' + '_orb_s22.out', 'w') as outfile:
+        with open(self.results_directory+'thin_d_orb_s22.out', 'w') as outfile:
             norbw = len(orbw)
             outfile.write(("%12i" % len(hlz)) + '\n')
             for i in range(0, norbw):
@@ -562,7 +548,7 @@ class Decomposition:
         nowlz= np.ravel(np.where(((lzm_sign) > ocut[0]) | ((lzm_sign) <= ocut[1])))
         orbw_wlz[nowlz] = -999
         self.logger.info(f'check 3 - warm comp: {len(wlz)}.')
-        with open(savedir + 'warm_d' + '_orb_s22.out', 'w') as outfile:
+        with open(self.results_directory+'warm_d_orb_s22.out', 'w') as outfile:
             norbw = len(orbw)
             outfile.write(("%12i" % len(wlz)) + '\n')
             for i in range(0, norbw):
@@ -580,7 +566,7 @@ class Decomposition:
         nozlz= np.ravel(np.where(((lzm_sign) > ocut[1]) | ((lzm_sign) <= ocut[2])))
         orbw_zlz[nozlz] = -999
         self.logger.info(f'check 3 - hot comp: {len(zlz)}.')
-        with open(savedir + 'bulge' + '_orb_s22.out', 'w') as outfile:
+        with open(self.results_directory+'bulge_orb_s22.out', 'w') as outfile:
             norbw = len(orbw)
             outfile.write(("%12i" % len(zlz)) + '\n')
             for i in range(0, norbw):
@@ -598,7 +584,7 @@ class Decomposition:
         orbw_dlz[nodlz] = -999
         self.logger.info(f'check 3 - disk comp: {len(dlz)}.')
 
-        with open(savedir + 'disk' + '_orb_s22.out', 'w') as outfile:
+        with open(self.results_directory + 'disk_orb_s22.out', 'w') as outfile:
             norbw = len(orbw)
             outfile.write(("%12i" % len(dlz)) + '\n')
             for i in range(0, norbw):
@@ -612,7 +598,7 @@ class Decomposition:
         orbw_allz = np.copy(orbw)
 
         self.logger.info(f'check 3 - whole comp: {len(orbw_allz)}.')
-        with open(savedir + 'all' + '_orb_s22.out', 'w') as outfile:
+        with open(self.results_directory + 'all_orb_s22.out', 'w') as outfile:
             norbw = len(orbw)
             outfile.write(("%12i" % len(orbw)) + '\n')
             for i in range(0, norbw):


### PR DESCRIPTION
Streamlining `plotter.py` in previous commits included removing the methods `Plotter.readorbout()`, `Plotter.triaxreadparameters()`, and `Plotter.readorbclass()`, breaking `Decomposition.plot_decomp()`.

This PR fixes `Decomposition.plot_decomp()` by removing the dependencies on these methods.

Tested with `test_decomp.py`. Please test, too and have a look at the changed code, then delete commented out lines referring to the deprecated methods and merge ;-)