### PR TITLE
Orbit plot now works with scipy nnls

### DIFF
--- a/dev_tests/test_nnls.py
+++ b/dev_tests/test_nnls.py
@@ -109,9 +109,12 @@ def run_user_test(make_comp=False):
         print('The best 2 models:')
         c.all_models.get_best_n_models(n=2).pprint(max_lines=-1, max_width=-1)
 
-    return c.all_models.table, \
-        compare_file, \
-        c.settings.parameter_space_settings['stopping_criteria']['n_max_mods']
+    if make_comp:
+        return c.all_models.table, \
+          compare_file, \
+          c.settings.parameter_space_settings['stopping_criteria']['n_max_mods']
+    else:
+        return c
 
 def create_comparison_data():
 
@@ -128,6 +131,6 @@ def create_comparison_data():
 
 if __name__ == '__main__':
     # create_comparison_data()
-    run_user_test()
+    c = run_user_test()
 
 # end

--- a/docs/more_info/changelog.rst
+++ b/docs/more_info/changelog.rst
@@ -4,6 +4,7 @@
 Change Log
 ****************
 
+- Improvement: the orbit plot (Plotter.orbit_plot) now works for all implemented weight solvers
 - Bugfix: fixed a bug that under certain circumstances prevented the staging files from being deleted after a successful iteration
 - Bugfix: removed logging from the list of requirements because it is in the Python standard library
 - New feature: added a new DYNAMITE module orbit_exploration, its first class Decompostion creates decomposition plots

--- a/dynamite/plotter.py
+++ b/dynamite/plotter.py
@@ -971,7 +971,7 @@ class Plotter():
         return res
 
 #############################################################################
-    
+
     def NFW_enclosemass(self, mstars=None, cc=None, dmfrac=None, R=None):
 
         #Computes density scale, radial scale and total mass in
@@ -985,7 +985,7 @@ class Plotter():
 
         rhoc = (200./3.)*rho_crit*cc**3/(np.log(1.+cc) - cc/(1.+cc))
         rc = (3./(800.*np.pi*rho_crit*cc**3)*dmfrac*mstars)**(1./3.)
-        
+
         #darkmass = (800./3.)*np.pi*rho_crit*(rc*cc)**3
 
         M = 4. * np.pi * rhoc * rc**3 * (np.log((rc + R)/rc) - R/(rc + R))
@@ -1275,7 +1275,7 @@ class Plotter():
 ######## Routines from schw_orbit.py, necessary for orbit_plot ##############
 #############################################################################
 
-    def orbit_plot(self, model=None, Rmax_arcs=None, figtype =None):
+    def orbit_plot(self, model=None, Rmax_arcs=None, figtype=None, test=0):
         """
         Generates an orbit plot for the selected model
 
@@ -1311,6 +1311,9 @@ class Plotter():
 
         """
 
+        weight_solver = self.config.settings.weight_solver_settings['type']
+        if test == 0 and weight_solver == 'NNLS':
+            test +=1
         if figtype is None:
             figtype = '.png'
 
@@ -1355,8 +1358,14 @@ class Plotter():
         orbclass2 = np.genfromtxt(file3).T
         orbclass2 = orbclass1.reshape((5,ncol,norb), order='F')
 
+        if test == 0:
         # norbout, ener, i2, i3, regul, orbtype, orbw, lcut, ntot = self.readorbout(filename=file4)
-        orbw = np.genfromtxt(file4, skip_header=1, usecols=(6))
+            orbw = np.genfromtxt(file4, skip_header=1, usecols=(6))
+        else:
+            orblib = model.get_orblib()
+            _ = model.get_weights(orblib)
+            orbw = model.weights
+            print(orbw)
 
         orbclass=np.dstack((orbclass1,orbclass1,orbclass2))
         orbclass1a=np.copy(orbclass1)
@@ -1412,7 +1421,9 @@ class Plotter():
 
         ### plot the orbit distribution on lambda_z vs. r ###
 
-        filename5 = self.plotdir + 'orbit_linear_only' + figtype
+        filename5 = self.plotdir + f'orbit_linear_only_{weight_solver}' + figtype
+        if test == 0:
+            filename5 = f'{self.plotdir}orbit_library_only_{weight_solver}OLD{figtype}'
         imgxrange = xbinned
         imgyrange = ybinned
         extent = [imgxrange[0], imgxrange[1], imgyrange[0], imgyrange[1]]
@@ -1446,6 +1457,12 @@ class Plotter():
         #lzm = np.sum((lz), axis=0)/ndither **3
         #angular2= np.abs(np.sum((lzm[t[0:y+1]])*orbw[t[0:y+1]])/np.sum(orbw[t[0:y+1]]))
 
+        if test == 0:
+            test += 1
+            self.orbit_plot(model=model,
+                            Rmax_arcs=Rmax_arcs,
+                            figtype=figtype,
+                            test=test)
         return fig
 
     def shiftedColorMap(self,

--- a/dynamite/plotter.py
+++ b/dynamite/plotter.py
@@ -1365,7 +1365,6 @@ class Plotter():
             orblib = model.get_orblib()
             _ = model.get_weights(orblib)
             orbw = model.weights
-            print(orbw)
 
         orbclass=np.dstack((orbclass1,orbclass1,orbclass2))
         orbclass1a=np.copy(orbclass1)

--- a/dynamite/plotter.py
+++ b/dynamite/plotter.py
@@ -1275,7 +1275,7 @@ class Plotter():
 ######## Routines from schw_orbit.py, necessary for orbit_plot ##############
 #############################################################################
 
-    def orbit_plot(self, model=None, Rmax_arcs=None, figtype=None, test=0):
+    def orbit_plot(self, model=None, Rmax_arcs=None, figtype=None):
         """
         Generates an orbit plot for the selected model
 
@@ -1311,9 +1311,6 @@ class Plotter():
 
         """
 
-        weight_solver = self.config.settings.weight_solver_settings['type']
-        if test == 0 and weight_solver == 'NNLS':
-            test +=1
         if figtype is None:
             figtype = '.png'
 
@@ -1336,11 +1333,11 @@ class Plotter():
         mdir = model.directory
         mdir_noml = mdir[:mdir[:-1].rindex('/')+1]
 
-        file4 = mdir + 'nn_orb.out'
         file2 = mdir_noml + 'datfil/orblib.dat_orbclass.out'
         file3 = mdir_noml + 'datfil/orblibbox.dat_orbclass.out'
         file3_test = os.path.isfile(file3)
-        if not file3_test: file3= '%s' % file2
+        if not file3_test:
+            file3= '%s' % file2
 
         xrange=[0.0,Rmax_arcs]
 
@@ -1358,13 +1355,9 @@ class Plotter():
         orbclass2 = np.genfromtxt(file3).T
         orbclass2 = orbclass1.reshape((5,ncol,norb), order='F')
 
-        if test == 0:
-        # norbout, ener, i2, i3, regul, orbtype, orbw, lcut, ntot = self.readorbout(filename=file4)
-            orbw = np.genfromtxt(file4, skip_header=1, usecols=(6))
-        else:
-            orblib = model.get_orblib()
-            _ = model.get_weights(orblib)
-            orbw = model.weights
+        orblib = model.get_orblib()
+        _ = model.get_weights(orblib)
+        orbw = model.weights
 
         orbclass=np.dstack((orbclass1,orbclass1,orbclass2))
         orbclass1a=np.copy(orbclass1)
@@ -1376,8 +1369,8 @@ class Plotter():
 
         ## define circularity of each orbit [nditcher^3, norb]
         lz = (orbclass[2,:,:]/orbclass[3,:,:]/np.sqrt(orbclass[4,:,:]))   # lambda_z = lz/(r * Vrms)
-        # lx = (orbclass[0,:,:]/orbclass[3,:,:]/np.sqrt(orbclass[4,:,:]))   # lambda_x = lx/(r * Vrms)
-        # l= (np.sqrt(np.sum(orbclass[0:3,:,:]**2, axis=0))/orbclass[3,:,:]/np.sqrt(orbclass[4,:,:]))
+        # lx = (orbclass[0,:,:]/orbclass[3,:,:]/np.sqrt(orbclass[4,:,:])) # lambda_x = lx/(r * Vrms)
+        # l=(np.sqrt(np.sum(orbclass[0:3,:,:]**2, axis=0))/orbclass[3,:,:]/np.sqrt(orbclass[4,:,:]))
         r = (orbclass[3,:,:]/conversion_factor)   # from km to kpc
 
         # average values for the orbits in the same bundle (ndither^3).
@@ -1420,9 +1413,7 @@ class Plotter():
 
         ### plot the orbit distribution on lambda_z vs. r ###
 
-        filename5 = self.plotdir + f'orbit_linear_only_{weight_solver}' + figtype
-        if test == 0:
-            filename5 = f'{self.plotdir}orbit_library_only_{weight_solver}OLD{figtype}'
+        filename5 = self.plotdir + 'orbit_linear_only' + figtype
         imgxrange = xbinned
         imgyrange = ybinned
         extent = [imgxrange[0], imgxrange[1], imgyrange[0], imgyrange[1]]
@@ -1456,12 +1447,6 @@ class Plotter():
         #lzm = np.sum((lz), axis=0)/ndither **3
         #angular2= np.abs(np.sum((lzm[t[0:y+1]])*orbw[t[0:y+1]])/np.sum(orbw[t[0:y+1]]))
 
-        if test == 0:
-            test += 1
-            self.orbit_plot(model=model,
-                            Rmax_arcs=Rmax_arcs,
-                            figtype=figtype,
-                            test=test)
         return fig
 
     def shiftedColorMap(self,


### PR DESCRIPTION
`Plotter.orbit_plot()` now reads the orbit weights using standard DYNAMITE methods and does no longer rely on legacy weight solver's output files.

The code has some testing features in it and needs cleanup before merging.

Please test. Hints & expected behavior:

- Execute the model iterator (ested with dev_tests/test_nnls.py so far).
- Create an orbit plot. E.g., via
```
p = dyn.plotter.Plotter(c)
p.orbit_plot(Rmax_arcs=3000)
```
- In case of the legacy weight solver, there should be two identical figures orbit_library_only_LegacyWeightSolverOLD.png and orbit_linear_only_LegacyWeightSolver.png in the plots directory.
In case of the scipy nnls weight solver, there should be one figure orbit_linear_only_NNLS.png in the plots directory.

Many thanks and cheers,
Thomas