### PR TITLE
Make without galahad

### DIFF
--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -125,10 +125,17 @@ Download from `github <https://github.com/dynamics-of-stellar-systems/dynamite>`
 
 If you encouter problems during the installation process, have a look at the section :ref:`troubleshooting`. Some of the most common issues are gathered there.
 
-The installation of DYNAMITE consists of three steps, as detailed below.a
+There are two major installation options for DYNAMITE:
+
+(A) DYNAMITE with the GALAHAD (the ``LegacyWeightSolver``) and the SciPy-based ``NNLS`` weight solvers.
+(B) DYNAMITE with just the SciPy-based ``NNLS`` weight solver.
+
+In case of installation option (A), the installation of DYNAMITE consists of three steps; in case of (B), it consists of two steps, as detailed below.
 
 1. Installation of GALAHAD
 --------------------------
+
+NOTE: this section (Installation of GALAHAD) only applies to DYNAMITE installation option (A).
 
 GALAHAD is a "library of thread-safe Fortran 90 packages for large-scale nonlinear optimization". The DYNAMITE code comes with Version 2.3.  An updated version of GALAHAD could be obtained `here <http://www.galahad.rl.ac.uk/doc.html>`_ (last updated in 2018), but the most recent version seems to not work. The GALAHAD package included in DYNAMITE can be found in the folder ``.../legacy_fortran``.
 
@@ -308,10 +315,14 @@ Update in .bashrc::
 
 Go back to ``.../legacy_fortran``. Before you proceed, it is necessary to make the following changes to the ``Makefile``:
 
-* Select the appropriate choice of ``GALAHADTYPE`` variable depending on your system (comment out the options that don't apply')
+* DYNAMITE installation option (A) only: Select the appropriate choice of ``GALAHADTYPE`` variable depending on your system (comment out the options that don't apply')
 * Look for the definition of the ``all:`` (this should be right after the definition of the ``GALAHADTYPE`` variable). Make sure that ``triaxgasnnls`` is **NOT** in the list.
 
-Proceed with the following command from the terminal::
+Proceed with the following command from the terminal, depending on your choice of the DYNAMITE installation option.
+
+DYNAMITE installation option (A)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+::
 
     make all
 
@@ -320,9 +331,25 @@ Your terminal will likely express several warnings again, but these are not crit
 * modelgen
 * orbitstart
 * orblib
+* orblib_new_mirror
 * triaxmass
 * triaxmassbin
 * triaxnnls_CRcut
+* triaxnnls_noCRcut
+
+DYNAMITE installation option (B)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+::
+
+    make nogal
+
+Your terminal will likely express several warnings again, but these are not critical and refer to different coding conventions in earlier Fortran versions. Now, take a look in the directory ``.../legacy_fortran`` and check that you have .f90 files and executables (no file name extension) for:
+
+* orbitstart
+* orblib
+* orblib_new_mirror
+* triaxmass
+* triaxmassbin
 
 
 3. Installing DYNAMITE

--- a/docs/more_info/changelog.rst
+++ b/docs/more_info/changelog.rst
@@ -4,6 +4,7 @@
 Change Log
 ****************
 
+- Improvement: DYNAMITE can now be built without GALAHAD (LegacyWeightSolver will not be available then)
 - Improvement: plotting gh kinematic maps is more efficient and now works for all weight solvers
 - New feature: New parameter generator SpecificModels generates and runs a predefined list of models or models resulting from a cartesian product of parameter values
 - Improvement: the orbit plot (Plotter.orbit_plot) now works for all implemented weight solvers

--- a/legacy_fortran/Makefile
+++ b/legacy_fortran/Makefile
@@ -101,6 +101,7 @@ GALAHADTYPE= mac.osx.gfo/double/
 ##########################################################
 
 all : orbitstart orblib orblib_new_mirror triaxmass triaxmassbin triaxnnls_CRcut triaxnnls_noCRcut modelgen
+nogal : orbitstart orblib orblib_new_mirror triaxmass triaxmassbin
 
 #########################################################
 #

--- a/legacy_fortran/Makefile.linux
+++ b/legacy_fortran/Makefile.linux
@@ -106,6 +106,7 @@ GALAHADTYPE= pc.lnx.gfo/double
 ##########################################################
 
 all : orbitstart orblib orblib_new_mirror triaxmass triaxmassbin triaxnnls_CRcut triaxnnls_noCRcut modelgen
+nogal : orbitstart orblib orblib_new_mirror triaxmass triaxmassbin
 
 #########################################################
 #

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import os
 import setuptools
 
 # this loads the version number from the dynamite/version.py module
@@ -14,16 +15,17 @@ with open("requirements.txt", "r") as fp:
     required = fp.read().splitlines()
 
 legacy_fortran = [
-    "../legacy_fortran/modelgen",
     "../legacy_fortran/orbitstart",
     "../legacy_fortran/orblib",
     "../legacy_fortran/orblib_new_mirror",
-    "../legacy_fortran/partgen",
     "../legacy_fortran/triaxmass",
     "../legacy_fortran/triaxmassbin",
-    "../legacy_fortran/triaxnnls_CRcut",
-    "../legacy_fortran/triaxnnls_noCRcut",
 ]
+additional_ex = ["../legacy_fortran/modelgen",
+                 "../legacy_fortran/partgen",
+                 "../legacy_fortran/triaxnnls_CRcut",
+                 "../legacy_fortran/triaxnnls_noCRcut"]
+legacy_fortran.extend([e for e in additional_ex if os.path.isfile(e)])
 
 setuptools.setup(
     name="dynamite",


### PR DESCRIPTION
DYNAMITE can now be built without GALAHAD (`LegacyWeightSolver` will not be available then, only `NNLS`/`scipy`).
Use `make nogal` instead of `make all`. This should not require GALAHAD any more.

Please test that - after `make distclean` and deleting the entire dynamite (incl. legacy_fortran) installation directories - DYNAMITE installs correctly. Especially, `setup.py` should install the legacy weight solver files only if they are present in the `legacy_fortran` directory.

Connected to this: do we still need `modelgen` in legacy_fortran?