### PR TITLE
PSF weight check

### DIFF
--- a/dynamite/data.py
+++ b/dynamite/data.py
@@ -72,11 +72,21 @@ class Integrated(Data):
         self.aperturefile = aperturefile
         self.binfile = binfile
         super().__init__(**kwargs)
+        self.logger = logging.getLogger(f'{__name__}.{__class__.__name__}')
         if hasattr(self, 'data'):
             self.PSF = self.data.meta['PSF']
+            if abs(sum(self.PSF['weight'])-1.0) > 1e-8:
+                txt = f"PSF weights add up to {sum(self.PSF['weight'])}, " + \
+                      "not 1.0."
+                if hasattr(self, 'datafile'):
+                    txt += ' Check input data in '
+                    if hasattr(self, 'input_directory'):
+                        txt += f'{self.input_directory}'
+                    txt += f'{self.datafile}.'
+                self.logger.error(txt)
+                raise ValueError(txt)
         if self.aperturefile is not None and self.binfile is not None:
             self.read_aperture_and_bin_files()
-        self.logger = logging.getLogger(f'{__name__}.{__class__.__name__}')
 
     def add_psf_to_datafile(self,
                             sigma=[1.],


### PR DESCRIPTION
Added a check to make sure the sum of all elements in the kinematic psf "weight" = 1.0 (1e-8 accuracy).

So far tested with `test_nnls.py` (only one PSF).

@sthater / @juliala254 : if you have time, please test with your erroneous input data where the PSF weights did not add up to 1.0. DYNAMITE should crash with a useful error message immediately.
If the PSF weights add up to 1.0, DYNAMITE should run as expected.

Is Julia's account still active? I could not add her to the reviewers' list...

Closes #302.