### PR TITLE
Validate the content of the config file against the model's config file.

### DIFF
--- a/dynamite/model.py
+++ b/dynamite/model.py
@@ -806,13 +806,13 @@ class Model(object):
 
     def validate_config_file(self):
         """
-        validate the content of the config file against the model's config file
+        Validate the content of the config file against the model's config file
 
         Upon solving a model, DYNAMITE creates a backup of the config file in
         the model directory. Instantiating a model later (e.g., for plotting)
         using a config file that is incompatible with the one used to create
         the model can lead to problems (e.g., differently sized orbit library).
-        This method validates the "global" config file to the one in the
+        This method validates the "global" config file against the one in the
         model directory (if existing).
 
         Differing config files may be ok and intended (e.g., due to expanding

--- a/dynamite/model.py
+++ b/dynamite/model.py
@@ -1,5 +1,7 @@
 import os
 import copy
+import glob
+import difflib
 import logging
 import shutil
 import numpy as np
@@ -800,6 +802,78 @@ class Model(object):
         self.directory_noml=self.directory[:self.directory[:-1].rindex('/')+1]
         self.logger.debug('Model directory string up to ml: '
                           f'{self.directory_noml}')
+        self.validate_config_file()
+
+    def validate_config_file(self):
+        """
+        validate the content of the config file against the model's config file
+
+        Upon solving a model, DYNAMITE creates a backup of the config file in
+        the model directory. Instantiating a model later (e.g., for plotting)
+        using a config file that is incompatible with the one used to create
+        the model can lead to problems (e.g., differently sized orbit library).
+        This method validates the "global" config file to the one in the
+        model directory (if existing).
+
+        Differing config files may be ok and intended (e.g., due to expanding
+        the parameter space). Therefore, the main purpose of this method is to
+        add warnings to the log to alert the user.
+
+        Raises
+        ------
+        FileNotFoundError
+            If the "global" config file cannot be found.
+
+        Returns
+        -------
+        bool
+            ``False`` if a config file backup is successfully found in the
+            model directory and it differs from the "global" config file.
+            ``True`` otherwise (no config file backup could be identified or
+            the config file backup is identical to the global config file).
+
+        """
+        if not os.path.isfile(self.config.config_file_name):
+            txt = f'Unexpected: config file {self.config.config_file_name}' + \
+                  'not found.'
+            self.logger.error(txt)
+            raise FileNotFoundError(txt)
+        model_yaml_files = glob.glob(self.directory+'*.yaml')
+        n_yaml_files = len(model_yaml_files)
+        if n_yaml_files == 0:
+            self.logger.debug(f'No config file backup in {self.directory} '
+                              'found - probably a new model.')
+            return True  # ####################
+        if n_yaml_files == 1:
+            f_i = 0
+        else:
+            try:
+                f_i = model_yaml_files.index(self.directory +
+                                             self.config.config_file_name)
+            except ValueError:
+                self.logger.warning('More than one .yaml file found in '
+                                    f'{self.directory}, no file name match'
+                                    'with the config file, no check possible.')
+                return True  # ####################
+        model_config_file_name = model_yaml_files[f_i]
+        with open(self.config.config_file_name) as c_f:
+            config_file = c_f.readlines()
+        with open(model_config_file_name) as c_f:
+            model_config_file = c_f.readlines()
+        c_diff = difflib.unified_diff(config_file,
+                                      model_config_file,
+                                      fromfile=self.config.config_file_name,
+                                      tofile=model_config_file_name)
+        c_diff = list(c_diff)
+        if len(c_diff) > 0:
+            self.logger.warning('ACTION REQUIRED, PLEASE CHECK: '
+                                'The current config file '
+                                f'{self.config.config_file_name} differs from '
+                                f'the config file {model_config_file_name} '
+                                'backup in the model directory. Diff output:\n'
+                                f'{"".join(c_diff)}.')
+            return False  # ####################
+        return True
 
     def get_model_directory(self):
         """get the name of this model's output directory


### PR DESCRIPTION
Upon solving a model, DYNAMITE creates a backup of the config file in the model directory. Instantiating a model later (e.g., for plotting) using a config file that is incompatible with the one used to create the model can lead to problems (e.g., differently sized orbit library).

This PR implements a method that validates the "global" config file against the one in the model directory (if it exists).

Given that differing config files may be ok and intended (e.g., due to expanding the parameter space), this method adds warnings to the log to alert the user and DYNAMITE continues to run.

Testing:
1. Run DYNAMITE (e.g., `test_nnls.py`)
2. In the "best model" directory, change any portion of the backed-up config file (e.g., change a parameter's lo/hi value in `NGC6278_output/models/orblib_000_000/ml01.00/user_test_config_ml.yaml`)
3. Execute a plot that re-instantiates the "best" model (e.g.,
```
c = dyn.config_reader.Configuration('user_test_config_ml.yaml', reset_logging=True, user_logfile='test_nnls', reset_existing_output=False)
p = dyn.plotter.Plotter(c)
p.orbit_plot(Rmax_arcs=20)
```
You should see a WARNING message in the log indicating that the config files differ, along with the diff output.
