### PR TITLE
Updated requirements

### DIFF
--- a/dynamite/kinematics.py
+++ b/dynamite/kinematics.py
@@ -753,7 +753,7 @@ class Histogram(object):
             return a*np.exp(-(x-mean)**2/(2.*sigma**2))
         for orbit in range(self.y.shape[0]):
             for aperture in range(self.y.shape[-1]):
-                err_msg=f'{orbit=}, {aperture=}: both mean and sigma are nan.'
+                err_msg=f'{orbit=}, {aperture=}: mean or sigma is nan.'
                 if not (np.isnan(v_mean[orbit,aperture]) or
                         np.isnan(v_sigma[orbit,aperture])): # nan?
                     p_initial = [1/(v_sigma[orbit,aperture]*np.sqrt(2*np.pi)),

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,12 +4,12 @@ cvxopt>=1.2.6
 h5py>=3.1.0
 lmfit
 matplotlib>=3.3.4
-numpy<=1.24,>=1.20.1
+numpy<1.25,>=1.21
 pafit>=2.0.7
 pathos>=0.2.7
 plotbin>=3.1.3
 PyYAML>=5.4.1
-scipy>=1.6.0
+scipy>=1.10
 six
 sparse>=0.14.0
 vorbin>=3.1.4

--- a/setup.py
+++ b/setup.py
@@ -38,13 +38,13 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     classifiers=[
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
     project_urls={
         "Source": "https://github.com/dynamics-of-stellar-systems/dynamite/",
         "Documentation": "https://dynamics.univie.ac.at/dynamite_docs/index.html",
     },
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     # use the already parsed requirements from requirements.txt
     install_requires=required,
     package_data={

--- a/setup.py
+++ b/setup.py
@@ -21,10 +21,10 @@ legacy_fortran = [
     "../legacy_fortran/triaxmass",
     "../legacy_fortran/triaxmassbin",
 ]
-additional_ex = ["../legacy_fortran/modelgen",
-                 "../legacy_fortran/triaxnnls_CRcut",
-                 "../legacy_fortran/triaxnnls_noCRcut"]
-legacy_fortran.extend([e for e in additional_ex if os.path.isfile(e)])
+additional_ex = ["legacy_fortran/modelgen",
+                 "legacy_fortran/triaxnnls_CRcut",
+                 "legacy_fortran/triaxnnls_noCRcut"]
+legacy_fortran.extend([f'../{e}' for e in additional_ex if os.path.isfile(e)])
 
 setuptools.setup(
     name="dynamite",


### PR DESCRIPTION
The `numba` package is part of the `astropy` requirements and does not support the latest `numpy` version. Therefore, the requirements have been updated accordingly.
Also, the required python version >= 3.8 from the documentation is added to `setup.py` now.