### PR TITLE
Better crash recovery

### DIFF
--- a/docs/more_info/changelog.rst
+++ b/docs/more_info/changelog.rst
@@ -4,6 +4,11 @@
 Change Log
 ****************
 
+- Improvement: better crash recovery: re-use existing tube orbits when recalculating orblib, bugfix in retrofitting kinmapchi2 in old all_models tables
+
+Version: 4.0
+================
+
 - New feature: kinmapchi2 (directly calculated from the kinematic maps) is now also available for the python NNLS solver
 - New feature: added support for bar/disk decomposition
 - New feature: added support for getting intrinsic model moments for both Gauss Hermite and a BayesLOSVD models

--- a/dynamite/config_reader.py
+++ b/dynamite/config_reader.py
@@ -480,6 +480,8 @@ class Configuration(object):
         self.all_models = model.AllModels(config=self)
         logger.info('Instantiated AllModels object')
         logger.debug(f'AllModels:\n{self.all_models.table}')
+        self.all_models.update_model_table()
+        logger.info('all_models table updated and saved.')
 
         # self.backup_config_file(reset=False)
 

--- a/dynamite/model.py
+++ b/dynamite/model.py
@@ -39,7 +39,7 @@ class AllModels(object):
             self.logger.info('Previous models have been found: '
                         f'Reading {self.filename} into '
                         f'{__class__.__name__}.table')
-            self.read_model_file()
+            self.read_model_table()
         else:
             self.logger.info(f'No previous models (file {self.filename}) '
                         'have been found: '
@@ -88,7 +88,7 @@ class AllModels(object):
         dtype.append('U256')
         self.table = table.Table(names=names, dtype=dtype)
 
-    def read_model_file(self):
+    def read_model_table(self):
         """Read table from file ``self.filename``
 
         Returns
@@ -107,25 +107,29 @@ class AllModels(object):
     def update_model_table(self):
         """all_models table update: fix incomplete models, add kinmapchi2.
 
-        Dealing with incomplete models:
+        Dealing with incomplete models (all_done==False):
 
-        1. If the box orbits have not been integrated, but the tube orbit
+        * Check whether the model has been completed and not been updated
+        in the all_models table before a crash. If so, update the all_models
+        table with the staging file.
+
+        * If the box orbits have not been integrated, but the tube orbit
         library is finished, then orblib_done==False but the output files from
-        the box orbit integration will be in the model directory. In that case,
-        try to integrate the box orbits only.
+        the box orbit integration will exist in the model directory. In that
+        case, try to integrate the box orbits only.
 
-        2. Models with all_done==False but an existing model_done_staging.ecsv
-        will be updated in the table and the staging file will be deleted.
-        Models with all_done==False and no existing orblib will be deleted
+        * Models with all_done==False and no existing orblib will be deleted
         from the table and their model directory will be deleted, too.
-        The configuration setting reattempt_failures determines how partially
+
+        * The configuration setting reattempt_failures determines how partially
         completed models with all_done==False but existing orblibs are treated:
         If reattempt_failures==True, their orblib_done will be set to True
         and later the ModelIterator will execute the weight solving
         based on the existing orblibs.
         If reattempt_failures==False, the model and its directory will be
         deleted.
-        Note that orbit libraries on disk will not be deleted if
+
+        * Note that orbit libraries on disk will not be deleted if
         in use by other models.
 
         Returns
@@ -139,14 +143,10 @@ class AllModels(object):
             if not row['all_done']:
                 table_modified = True
                 mod = self.get_model_from_row(i)
+                # First, check whether the model has been completed. If so,
+                # then update the all_models table with the staging file.
                 staging_filename = mod.directory + 'model_done_staging.ecsv'
-                # If tube and box orbits exist, mod.get_orblib() will do
-                # nothing and just return the orblib object. Otherwise, it will
-                # try to calculate the missing orbits and return the orblib.
-                orblib = mod.get_orblib()
-                check_if_orblibs_present = all(orblib.check_orlib_files())
                 if os.path.isfile(staging_filename):
-                    # the model has completed but was not entered in the table
                     staging_file = ascii.read(staging_filename)
                     self.table[i] = staging_file[0]
                     self.logger.info(f'Staging file {staging_filename} '
@@ -154,13 +154,28 @@ class AllModels(object):
                     os.remove(staging_filename)
                     self.logger.debug(
                         f'Staging file {staging_filename} deleted.')
-                elif check_if_orblibs_present:
-                    self.logger.debug(f'Row {i}: orblibs were computed '
-                                      'but not weights.')
-                    self.table[i]['orblib_done'] = True
+                # If there is no staging file, check whether orblibs exist.
+                # If tube and box orbits exist, mod.get_orblib() will just
+                # return the orblib object. If tube orbits exist, it will try
+                # to calculate the missing box orbits and return the orblib.
                 else:
-                    self.logger.debug(f'Row {i}: neither orblibs nor '
-                                      'weights were completed.')
+                    cwd = os.getcwd()
+                    try:
+                        orblib = mod.get_orblib()
+                    except RuntimeError:
+                        os.chdir(cwd)
+                        w_txt = 'Cannot calculate orblib ' \
+                                f'{mod.directory_noml}, all_models table ' \
+                                f'row {i}): get_orblib failed.'
+                        self.logger.warning(w_txt)
+                    else:
+                        if all(orblib.check_orlib_files()):
+                            self.logger.debug(f'{mod.directory_noml}: orblibs '
+                                              'were computed but not weights.')
+                            self.table[i]['orblib_done'] = True
+                        else:
+                            self.logger.debug(f'{mod.directory_noml}: neither '
+                                              'orblibs nor weights completed.')
         # collect failed models to delete (both their directory and table entry)
         to_delete = []
         # if we will reattempt weight solving, only delete models with no orblib

--- a/dynamite/model.py
+++ b/dynamite/model.py
@@ -255,7 +255,8 @@ class AllModels(object):
                 weight_solver = getattr(ws, ws_type)(
                                         config=self.config,
                                         directory_with_ml=mod.directory)
-                _, _, _, row[which_chi2] = weight_solver.solve()
+                orblib = mod.get_orblib()
+                _, _, _, row[which_chi2] = weight_solver.solve(orblib)
                 self.logger.info(f'Model {row_id}: {which_chi2} = '
                                  f'{row[which_chi2]}')
             else:

--- a/dynamite/orblib.py
+++ b/dynamite/orblib.py
@@ -493,7 +493,7 @@ class LegacyOrbitLibrary(OrbitLibrary):
         cmdstr_tube, cmdstr_box = \
             self.write_executable_for_integrate_orbits(tube=tube, box=box)
         if tube:
-            self.logger.info('Integrating orbit library tube orbits')
+            self.logger.info('Integrating orbit library tube orbits.')
             # p = subprocess.call('bash '+cmdstr_tube, shell=True)
             p = subprocess.run('bash '+cmdstr_tube,
                                stdout=subprocess.PIPE,
@@ -517,7 +517,7 @@ class LegacyOrbitLibrary(OrbitLibrary):
                     self.logger.warning(text)
                     raise RuntimeError(text)
         if box:
-            self.logger.info('Integrating orbit library box orbits')
+            self.logger.info('Integrating orbit library box orbits.')
             # p = subprocess.call('bash '+cmdstr_box, shell=True)
             p = subprocess.run('bash '+cmdstr_box,
                                stdout=subprocess.PIPE,


### PR DESCRIPTION
Addressing @sthater's request in issue #179, this PR implements

- When DYNAMITE is interrupted, but tube orbit library is finished: check if it is finished and if yes, only calculate box orbits now.

Additionally, the following related bug fixes and improvements are part of this PR:

- Checking for the orblib integration output files now includes **all** relevant files created by the scripts calling legacy_fortran executables, not only `orblib.dat.bz2` and `orblibbox.dat.bz2`. The check now has its own method `LegacyOrbitLibrary.check_orlib_files()`.
- Bugfix: when reading an old all_models table which does not have the `kinmapchi2` column, the column was added but calculating the `kinmapchi2` values did not work (silently...). This is fixed in this PR.
- Separated reading an existing all_models table (`AllModels.read_model_table()`) from updating it (`AllModels.update_model_table()`) to avoid problems with the configuration object (`config_reader.py` takes care of this).
- Significantly updated the documentation of how DYNAMITE deals with incomplete models upon startup: see docstring of `AllModels.update_model_table()`.

Testing all this is a bit complex. Here's what has been done so far:
- (1) Run the original `test_nnls.py`. (2) In `test_nnls.py`:36, set `reset_existing_output=False`. (3) Delete any of the output files of the **tube** orbit integration script (`orblib.dat.bz2`, `orblib.dat_orbclass.out`, `mass_radmass.dat`, `mass_qgrid.dat`, `mass_aper.dat` in the `orblib_000_000/datfil` folder). (4) In `all_models.ecsv`, replace all `True` entries with `False`. (5) Re-run `test_nnls.py` and inspect the log. There should be the INFO message `Integrating orbit library tube and box orbits in parallel.` in the log because if the tube orbit files are not there, both tube+box need to be integrated.
- (1) Run the original `test_nnls.py`. (2) In `test_nnls.py`:36, set `reset_existing_output=False`. (3) Delete any of the output files of the **box** orbit integration script (`orblibbox.dat.bz2`, `orblibbox.dat_orbclass.out`). (4) In `all_models.ecsv`, replace all `True` entries with `False`. (5) Re-run `test_nnls.py` and inspect the log. There should be the INFO message `Tube orbits exist in NGC6278_output/models/orblib_000_000/, integrating box orbits only.` in the log because only the box orbits need to be integrated.
- (1) Run the original `test_nnls.py`. (2) In `test_nnls.py`:36, set `reset_existing_output=False`. (3) In `all_models.ecsv`, delete the `kinmapchi2` column (headline + 3 values) and its entry in the header (entire line 14). (5) Re-run `test_nnls.py` and inspect the output: `all_models.ecsv` should now have the `kinmapchi2` column with the correct values again. This test should also succeed when changing the weight solver in the config file (with some warnings because the config file will now differ from the one uses when initially creating `all_models.ecsv`).