### PR TITLE
Fix crash when using Python nnls and #coefficients in GH file does not match config file's number_GH

### DIFF
--- a/dynamite/kinematics.py
+++ b/dynamite/kinematics.py
@@ -555,7 +555,7 @@ class GaussHermite(Kinematics, data.Integrated):
         observed_values = np.zeros((self.n_apertures, max_gh_order))
         # h1, h2 = 0, 0
         # h3, h4, etc... are taken from the data table
-        for i in range(3, self.max_gh_order+1):
+        for i in range(3, max_gh_order+1):
             observed_values[:,i-1] = self.data[f'h{i}']
         # construct uncertainties
         uncertainties = np.zeros_like(observed_values)
@@ -563,7 +563,7 @@ class GaussHermite(Kinematics, data.Integrated):
         uncertainties[:,0] = self.data['dv']/np.sqrt(2)/self.data['sigma']
         uncertainties[:,1] = self.data['dsigma']/np.sqrt(2)/self.data['sigma']
         # uncertainties h3, h4, etc... are taken from data table
-        for i in range(3, self.max_gh_order+1):
+        for i in range(3, max_gh_order+1):
             uncertainties[:,i-1] = self.data[f'dh{i}']
         # add the systematic uncertainties
         systematics = weight_solver_settings['GH_sys_err']


### PR DESCRIPTION
Bugfix for: DYNAMITE crashes when using the Python nnls weight solver and the GH kinematics file had a larger number of coefficients than indicated in the config file (in `GaussHermite.get_observed_values_and_uncertainties()` allocation was based on the config file's number, two loops were based on the kinematics file column count).

To discuss:
In `kinematics.py`, the attribute `GaussHermite.max_gh_order` is calculated based on the number of columns in `gauss_hermite_kins.ecsv`. Wherever the maximum GH order is referenced in the code though, the value `number_GH` from the config file is used.
Shall we perhaps remove the attribute `GaussHermite.max_gh_order` to reduce confusion?

Tested with:
- `test_nnls.py` (#GH coefficients in `gauss_hermite_kins.ecsv` = config file's `number_GH` = 4)
- VSC5: `/home/fs71474/tmaindl/iris20230928/run_dyna_small.py`  (#GH coefficients in `gauss_hermite_kins.ecsv` = 6, config file's `number_GH` = 4).
Note that the second test crashes after weight solving because `Plotter.beta_plot()` only works with the `LegacyWeightSolver` (expects the file `nn_intrinsic_moments.out` to exist). This does not affect the validity of this PR though ;-)

Please have a look at the code changes (only two lines) and merge if satisfied ;-)