### PR TITLE
Fix for kinmapchi2 bug

### DIFF
--- a/dev_tests/test_multi_nnls.py
+++ b/dev_tests/test_multi_nnls.py
@@ -61,7 +61,7 @@ def run_user_test():
 
     c.all_models.table.pprint(max_lines=-1, max_width=-1)
 
-    # for one model, re-calculate solution with the new weight solver
+    # re-calculate solution with the new weight solver
     print('Recalculating orbit weights with scipy NNLS solver')
 
     fig, ax = plt.subplots(1, 3, sharey=True, figsize=(12,4))
@@ -72,15 +72,26 @@ def run_user_test():
                                                 mod_dir=mod0.directory_noml,
                                                 parset=parset0)
         orblib0.read_losvd_histograms()
-        weight_solver = mod0.get_weights()
-        weights_old, chi2_tot_old, chi2_kin_old = weight_solver.solve(orblib0)
+        weight_solver_old = dyn.weight_solvers.LegacyWeightSolver(
+                config=c,
+                directory_with_ml=mod0.directory,
+                CRcut=True)
+        solution_old = weight_solver_old.solve(orblib0,
+                                               ignore_existing_weights=True)
+        weights_old, chi2_tot_old, chi2_kin_old, chi2_kinmap_old = \
+            (s for s in solution_old)
         weight_solver_new = dyn.weight_solvers.NNLS(
                 config=c,
                 directory_with_ml=mod0.directory,
                 CRcut=True,
                 nnls_solver='scipy')
-        solution_new = weight_solver_new.solve(orblib0)
-        weights_new = solution_new[0]
+        solution_new = weight_solver_new.solve(orblib0,
+                                               ignore_existing_weights=True)
+        weights_new, chi2_tot_new, chi2_kin_new, chi2_kinmap_new = \
+            (s for s in solution_new)
+        print(f'Model {i}, {chi2_tot_old = }, {chi2_tot_new = }.')
+        print(f'Model {i}, {chi2_kin_old = }, {chi2_kin_new = }.')
+        print(f'Model {i}, {chi2_kinmap_old = }, {chi2_kinmap_new = }.')
         ax[i].plot(weights_old, label='Legacy')
         ax[i].plot(weights_new, '--', label='NNLS scipy')
         ax[i].legend()

--- a/dynamite/kinematics.py
+++ b/dynamite/kinematics.py
@@ -179,12 +179,12 @@ class GaussHermite(Kinematics, data.Integrated):
         coefficients and optionally including the systematic errors.
         The `number_GH` setting from the configuration file determines the
         number of returned GH coefficients.
-    
-        If number_GH (configuration file) greater than max_GH_order (number of 
+
+        If number_GH (configuration file) greater than max_GH_order (number of
         gh coefficients in the kinematics file), columns with zeros
         `h<max_GH_order+1> dh<max_GH_order+1>` ... `h<number_GH> dh<number_GH>`
-        will be added to the gh kinematics data. If number_GH is less than 
-        `max_GH_order`, the corresponding columns will be removed from the 
+        will be added to the gh kinematics data. If number_GH is less than
+        `max_GH_order`, the corresponding columns will be removed from the
         kinematics data.
 
         Parameters
@@ -234,7 +234,7 @@ class GaussHermite(Kinematics, data.Integrated):
             self.logger.info(f'Kinematics {self.name}: '
                              f'removed gh columns {cols_to_remove}.')
             if cache_data:
-                self._data_raw = gh_data
+                self._data_raw = gh_data.copy(copy_data=True)
         if apply_systematic_error:
             # construct uncertainties
             uncertainties = np.zeros((self.n_apertures, number_gh))
@@ -259,7 +259,7 @@ class GaussHermite(Kinematics, data.Integrated):
             self.logger.debug(f'Kinematics {self.name}: applied systematic '
                               'errors and h1, h2 uncertainties.')
             if cache_data:
-                self._data_with_sys_err = gh_data
+                self._data_with_sys_err = gh_data.copy(copy_data=True)
         return gh_data
 
     def get_highest_order_gh_coefficient(self):

--- a/dynamite/weight_solvers.py
+++ b/dynamite/weight_solvers.py
@@ -43,7 +43,7 @@ class WeightSolver(object):
         self.CRcut = CRcut
         self.weight_file = f'{self.direc_with_ml}orbit_weights.ecsv'
 
-    def solve(self, orblib):
+    def solve(self, orblib, ignore_existing_weights=False):
         """Template solve method
 
         Specific implementations should override this.
@@ -51,6 +51,9 @@ class WeightSolver(object):
         Parameters
         ----------
         orblib : dyn.OrbitLibrary object
+        ignore_existing_weights : bool
+            If True, do not check for already existing weights and solve again.
+            Default is False.
 
         Returns
         -------
@@ -239,7 +242,7 @@ class LegacyWeightSolver(WeightSolver):
         nn_file.write(text)
         nn_file.close()
 
-    def solve(self, orblib=None):
+    def solve(self, orblib=None, ignore_existing_weights=False):
         """Main method to solve NNLS problem.
 
         Parameters
@@ -248,6 +251,9 @@ class LegacyWeightSolver(WeightSolver):
             This parameter is not used in this Legacy implementation (as all
             orbit library information is read from files). It is included here
             for consistency with later WeightSolver implementations
+        ignore_existing_weights : bool
+            If True, do not check for already existing weights and solve again.
+            Default is False.
 
         Returns
         -------
@@ -263,7 +269,7 @@ class LegacyWeightSolver(WeightSolver):
 
         """
         self.logger.info(f"Using WeightSolver: {__class__.__name__}")
-        if self.weight_file_exists():
+        if (not ignore_existing_weights) and self.weight_file_exists():
             self.logger.info("Reading NNLS solution from existing output.")
             results = ascii.read(self.weight_file)
             weights = results['weights']
@@ -739,7 +745,7 @@ class NNLS(WeightSolver):
         orb_gh[idx_cut[0], idx_cut[1], 0] = 3./dvhist
         return orb_gh
 
-    def solve(self, orblib):
+    def solve(self, orblib, ignore_existing_weights=False):
         """Solve for orbit weights
 
         **Note:** the returned chi2 values are not the same as
@@ -750,6 +756,9 @@ class NNLS(WeightSolver):
         orblib : dyn.OrbitLibrary
             must have attributes losvd_histograms, intrinsic_masses, and
             projected_masses
+        ignore_existing_weights : bool
+            If True, do not check for already existing weights and solve again.
+            Default is False.
 
         Returns
         -------
@@ -767,7 +776,7 @@ class NNLS(WeightSolver):
         self.logger.info(f"Using WeightSolver: {__class__.__name__}/"
                          f"{self.nnls_solver}")
         orblib.read_losvd_histograms()
-        if self.weight_file_exists():
+        if (not ignore_existing_weights) and self.weight_file_exists():
             results = ascii.read(self.weight_file, format='ecsv')
             self.logger.info("NNLS solution read from existing output")
             weights = results['weights']


### PR DESCRIPTION
Fix for kinmapchi2 bug:
- Data caching in `GaussHermite.get_data(...)` sometimes caused problems. This commit fixes this by using deep copy.
- The `WeightSolver.solve(...)` method has a new optional parameter `ignore_existing_weights` that allows ignoring existing weight data, forcing a new weight solving run. This is useful for diagnostics and fixes e.g., `dev_tests/test_multi_nnls.py`.

Now the kinmapchi2 values are in very good agreement between the different weight solvers, see test data below.

Open question: in calculating kinmapchi2, we so far have ignored the GH kinematics systematic errors. Perhaps it would be more consistent with the weight solving to include those (`kinematics_data = kin_data.get_data(self.settings, apply_systematic_error=True)` in `WeightSolver.chi2_kinmap(...)`, lines 121-122)?

Closes #336

Test results:

**FCC047 test runs, LegacyWeightSolver**

```
number_GH=3:
       m-bh         a-bh c-dh   f-dh  q-stars p-stars u-stars  ml        chi2            kinchi2           kinmapchi2
------------------ ----- ---- ------- ------- ------- ------- --- ----------------- ------------------ -----------------------
3162277.6601683795 0.001 10.0 1.25893     0.2     0.7  0.9999 5.5 416425.2884538298 60359.941437665395 115153.38302447945
3162277.6601683795 0.001 10.0 1.25893     0.2     0.7  0.9999 4.5 418670.8642388978  59810.58616600247  88574.86547229892
3162277.6601683795 0.001 10.0 1.25893     0.2     0.7  0.9999 6.5 421946.4129168541  66917.66017005831 165940.24584393486

number_GH=4:
       m-bh         a-bh c-dh   f-dh  q-stars p-stars u-stars  ml        chi2             kinchi2          kinmapchi2
------------------ ----- ---- ------- ------- ------- ------- --- ------------------ ----------------- ------------------
3162277.6601683795 0.001 10.0 1.25893     0.2     0.7  0.9999 5.5 424493.15420013765 65666.78023535715 113735.67888008912
3162277.6601683795 0.001 10.0 1.25893     0.2     0.7  0.9999 4.5  429197.1525016983 67539.82992857283  87613.20983329182
3162277.6601683795 0.001 10.0 1.25893     0.2     0.7  0.9999 6.5  429339.9158990041 71949.22739494297 164348.79223217713

number_GH=5:
       m-bh         a-bh c-dh   f-dh  q-stars p-stars u-stars  ml        chi2             kinchi2          kinmapchi2
------------------ ----- ---- ------- ------- ------- ------- --- ------------------ ----------------- ------------------
3162277.6601683795 0.001 10.0 1.25893     0.2     0.7  0.9999 5.5  424501.6272540993 65672.14007516083 113730.16386600249
3162277.6601683795 0.001 10.0 1.25893     0.2     0.7  0.9999 4.5 429210.03923869145 67547.53606716642  87602.64374101332
3162277.6601683795 0.001 10.0 1.25893     0.2     0.7  0.9999 6.5 429346.53733657196 71953.90520141821 164345.39048523517
```

**FCC047 test runs, Python NNLS**

```
number_GH=3:
       m-bh         a-bh c-dh   f-dh  q-stars p-stars u-stars  ml        chi2             kinchi2          kinmapchi2
------------------ ----- ---- ------- ------- ------- ------- --- ------------------ ----------------- ------------------
3162277.6601683795 0.001 10.0 1.25893     0.2     0.7  0.9999 5.5  416425.2884538317 60359.94143765696 115153.38311356283
3162277.6601683795 0.001 10.0 1.25893     0.2     0.7  0.9999 4.5 418670.86423890106 59810.58616606319  88574.86509793051
3162277.6601683795 0.001 10.0 1.25893     0.2     0.7  0.9999 6.5 421946.41291685525  66917.6601700391 165940.24559728603

number_GH=4:
       m-bh         a-bh c-dh   f-dh  q-stars p-stars u-stars  ml        chi2             kinchi2          kinmapchi2
------------------ ----- ---- ------- ------- ------- ------- --- ------------------ ----------------- ------------------
3162277.6601683795 0.001 10.0 1.25893     0.2     0.7  0.9999 5.5 424493.15420013946 65666.78023530384 113735.67911982398
3162277.6601683795 0.001 10.0 1.25893     0.2     0.7  0.9999 4.5  429197.1525017018 67539.82992860806  87613.20968621966
3162277.6601683795 0.001 10.0 1.25893     0.2     0.7  0.9999 6.5 429339.91589900514 71949.22739492588 164348.79271744133

number_GH=5:
       m-bh         a-bh c-dh   f-dh  q-stars p-stars u-stars  ml        chi2             kinchi2          kinmapchi2
------------------ ----- ---- ------- ------- ------- ------- --- ------------------ ----------------- ------------------
3162277.6601683795 0.001 10.0 1.25893     0.2     0.7  0.9999 5.5  424501.6272541011 65672.14007511585 113730.16423063162
3162277.6601683795 0.001 10.0 1.25893     0.2     0.7  0.9999 4.5 429210.03923869494 67547.53606718627  87602.64352996505
3162277.6601683795 0.001 10.0 1.25893     0.2     0.7  0.9999 6.5   429346.537336573 71953.90520141224 164345.39016516917
```