### PR TITLE
Misc little improvements

### DIFF
--- a/docs/more_info/changelog.rst
+++ b/docs/more_info/changelog.rst
@@ -4,6 +4,7 @@
 Change Log
 ****************
 
+- Improvement: the Plotter's new optional argument ``dpi`` (default: 100) allows to change the resolution of all saved figures except the kinematic maps (always 300 dpi).
 - Improvement: the beta plots now work for all implemented weight solvers.
 
 Version: 4.1

--- a/docs/more_info/changelog.rst
+++ b/docs/more_info/changelog.rst
@@ -4,6 +4,7 @@
 Change Log
 ****************
 
+- Improvement: removed deprecated silent option from config reader.
 - Improvement: the Plotter's new optional argument ``dpi`` (default: 100) allows to change the resolution of all saved figures except the kinematic maps (always 300 dpi).
 - Improvement: the beta plots now work for all implemented weight solvers.
 

--- a/dynamite/config_reader.py
+++ b/dynamite/config_reader.py
@@ -70,7 +70,7 @@ class Settings(object):
             raise ValueError(text)
 
     def validate(self):
-        """Validate that all expected settings are present
+        """Validate that all expected settings are present and perform checks
         """
         if not(self.orblib_settings and self.parameter_space_settings and
                self.io_settings and self.weight_solver_settings
@@ -80,6 +80,11 @@ class Settings(object):
                              and io_settings
                              and weight_solver_settings
                              and multiprocessing_settings"""
+            self.logger.error(text)
+            raise ValueError(text)
+        if self.orblib_settings['nI2'] < 4:
+            text = "orblib_settings: nI2 must be >= 4, but is " \
+                   f"{self.orblib_settings['nI2']}."
             self.logger.error(text)
             raise ValueError(text)
         self.logger.debug('Settings validated.')
@@ -839,10 +844,6 @@ class Configuration(object):
     def validate(self):
         """
         Validates the system and settings.
-
-        This includes aligning the number of gh coefficients with the config
-        file setting `number_GH` for Gauss Hermite kinematics and also applies
-        the weight solver settings' systematic errors to the kinematics.
 
         This method is still VERY rudimentary and will be adjusted as we add new
         functionality to dynamite. Currently, this method is geared towards

--- a/dynamite/config_reader.py
+++ b/dynamite/config_reader.py
@@ -121,8 +121,6 @@ class Configuration(object):
     ----------
     filename : string
         needs to refer to an existing file including path
-    silent : DEPRECATED
-        (diagnostic output handled by logging module)
     reset_logging : bool
         if False: use the calling application's logging settings
         if True: set logging to Dynamite defaults
@@ -160,7 +158,6 @@ class Configuration(object):
 
     def __init__(self,
                  filename=None,
-                 silent=None,
                  reset_logging=False,
                  user_logfile='dynamite',
                  reset_existing_output=False):
@@ -176,9 +173,6 @@ class Configuration(object):
         self.logger.debug(f'This is Python {sys.version.split()[0]}')
         self.logger.debug(f'Using DYNAMITE version {dyn.__version__} '
                           f'located at {dyn.__path__}')
-
-        if silent is not None:
-            self.logger.warning("'silent' option is deprecated and ignored")
 
         self.logger.debug('Global variables: ' \
                           f'{const.GRAV_CONST_KM = }, {const.PARSEC_KM = }, ' \

--- a/dynamite/plotter.py
+++ b/dynamite/plotter.py
@@ -34,7 +34,7 @@ class Plotter():
     ----------
     config : a ``dyn.config_reader.Configuration`` object
     dpi : float, optional
-        The resolution of saved figures if not specified elsewhere. The
+        The resolution of saved figures (if not overridden later). The
         default is 100 dpi.
 
     """

--- a/dynamite/plotter.py
+++ b/dynamite/plotter.py
@@ -33,9 +33,13 @@ class Plotter():
     Parameters
     ----------
     config : a ``dyn.config_reader.Configuration`` object
+    dpi : float, optional
+        The resolution of saved figures if not specified elsewhere. The
+        default is 100 dpi.
 
     """
-    def __init__(self, config=None):
+
+    def __init__(self, config=None, dpi=100):
         self.logger = logging.getLogger(f'{__name__}.{__class__.__name__}')
         if config is None:
             text = f'{__class__.__name__} needs configuration object, ' \
@@ -49,6 +53,7 @@ class Plotter():
         self.input_directory = config.settings.io_settings['input_directory']
         self.plotdir = config.settings.io_settings['plot_directory']
         self.modeldir = config.settings.io_settings['model_directory']
+        mpl.rcParams['savefig.dpi'] = dpi
 
     def make_chi2_vs_model_id_plot(self, which_chi2=None, figtype=None):
         """


### PR DESCRIPTION
This PR collects some minor improvements:
- The default resolution of saved images was (at 72 dpi) too low for some purposes. The Plotter's new optional argument `dpi` (default: 100) allows to change the resolution of all saved figures except the kinematic maps (always at 300 dpi).
- Config reader now checks for `nI2 >= 4` to avoid Fortran runtime errors later on.
- Removed deprecated `silent` option from config reader.

Tested with `test_nnls.py` and `tests_notebooks.sh`. Before merging a quick look over the few changed lines should be sufficient.