### PR TITLE
Sb profile plots

### DIFF
--- a/dev_tests/test_nnls.py
+++ b/dev_tests/test_nnls.py
@@ -133,5 +133,6 @@ def create_comparison_data():
 if __name__ == '__main__':
     # create_comparison_data()
     c = run_user_test()
-
+    p = dyn.plotter.Plotter(c)
+    p.plot_sb_profile(Rmax_arcs=15)
 # end

--- a/dynamite/analysis.py
+++ b/dynamite/analysis.py
@@ -79,6 +79,9 @@ class Decomposition:
     def plot_decomp(self, xlim, ylim, v_sigma_option='fit'):
         """ Generate decomposition plots.
 
+        The plots are written to the plots directory, the underlying data as
+        .ecsv astropy tables into the model directory.
+
         Parameters
         ----------
         xlim : float
@@ -271,8 +274,14 @@ class Decomposition:
                    xlim,
                    ylim,
                    comp_kinem_moments,
-                   figtype='.png'):
-        """ Generate decomposition plots.
+                   figtype='.png',
+                   return_table_only=False):
+        """ Generate decomposition plots based on components' (flux, v, dv)
+        vs aperture table.
+
+        The plots are written to the plots directory, the underlying data as
+        ecsv astropy tables into the model directory. If
+        `return_table_only=True`, nothing is written to disk.
 
         Parameters
         ----------
@@ -288,10 +297,16 @@ class Decomposition:
         figtype : str, optional
             Determines the file format and extension to use when saving the
             figure. The default is '.png'.
+        return_table_only : bool, optional
+            If True, this method does not create a plot or save data to disk,
+            but only returns the table with the components' kinematics.
+            The default is False.
 
         Returns
         -------
-        None.
+        comps_kin : astropy table (if `return_table_only=True`)
+            The astropy table holding the components' kinematics.
+        None : if `return_table_only=False`.
 
         """
 
@@ -364,6 +379,9 @@ class Decomposition:
                          labels[1]:vel[i][grid[s]],
                          labels[2]:sig[i][grid[s]]})
         comps_kin = astropy.table.Table(table)
+
+        if return_table_only:
+            return comps_kin  # ###############################################
 
         kin_name = stars.kinematic_data[self.kin_set].name
         file_name = f'comps_kin_{v_sigma_option}_{kin_name}'


### PR DESCRIPTION
The SB profile plots are added to `plotter.py`: `Plotter.plot_sb_profile(...)`.

Tested with `test_nnls.py`, the last 2 lines of that script create the `sb_profile.png` file in the plots directory. Very large scatter in this example (NGC6270), let's discuss... ;-)

Closes #351.