### PR TITLE
Use Kinematics.get_data() instead of Kinematics.data in DYNAMITE where possible

### DIFF
--- a/dynamite/config_reader.py
+++ b/dynamite/config_reader.py
@@ -544,10 +544,10 @@ class Configuration(object):
         for k in stars.kinematic_data:
             if k.type == 'GaussHermite':
                 number_GH = self.settings.weight_solver_settings['number_GH']
-                n_obs += number_GH * len(k.data)
+                n_obs += number_GH * k.n_spatial_bins
             if k.type == 'BayesLOSVD':
-                nvbins = k.data.meta['nvbins']
-                n_obs += nvbins * len(k.data)
+                nvbins = k.get_data().meta['nvbins']
+                n_obs += nvbins * k.n_spatial_bins
         two_n_obs = 2 * n_obs
         return two_n_obs
 

--- a/dynamite/kinematics.py
+++ b/dynamite/kinematics.py
@@ -49,6 +49,7 @@ class Kinematics(data.Data):
                    f'{self.hist_width}, {self.hist_center}, {self.hist_bins})'
                 self.logger.error(text)
                 raise ValueError(text)
+            self.n_spatial_bins = len(self.data)
 
     def update(self, **kwargs):
         """
@@ -89,10 +90,10 @@ class Kinematics(data.Data):
         return f'{self.__class__.__name__}({self.__dict__})'
 
     def get_data(self, **kwargs):
-        """Returns the kinemtics data.
+        """Returns the kinematics data.
 
-        This skeleton method just returns the self.data attribute and allows
-        for specific implementations by subclasses.
+        This skeleton method returns a deep copy of the self.data attribute
+        and allows for specific implementations by subclasses.
 
         Parameters
         ----------
@@ -164,7 +165,7 @@ class GaussHermite(Kinematics, data.Integrated):
         self.logger = logging.getLogger(f'{__name__}.{__class__.__name__}')
         if hasattr(self, 'data'):
             self.max_gh_order = self.get_highest_order_gh_coefficient()
-            self.n_apertures = len(self.data)
+            self.n_apertures = self.n_spatial_bins
             self._data_raw = None
             self._data_with_sys_err = None
 
@@ -178,7 +179,8 @@ class GaussHermite(Kinematics, data.Integrated):
         with their uncertainties, adapted to the desired number of GH
         coefficients and optionally including the systematic errors.
         The `number_GH` setting from the configuration file determines the
-        number of returned GH coefficients.
+        number of returned GH coefficients. The data in the returned table is
+        a deep copy of the observed data.
 
         If number_GH (configuration file) greater than max_GH_order (number of
         gh coefficients in the kinematics file), columns with zeros

--- a/dynamite/kinematics.py
+++ b/dynamite/kinematics.py
@@ -197,8 +197,8 @@ class GaussHermite(Kinematics, data.Integrated):
             is set to `True`, the key `GH_sys_err`.
         apply_systematic_error : bool, optional
             If set to `True`, apply the systematic uncertainties to the
-            dh3, dh4, ... values and calculates the h1, h2 uncertainties
-            from vdMarel + Franx 93.
+            dh3, dh4, ... values and calculates the dv, dsigma uncertainties
+            from vdMarel + Franx 93, ApJ 407,525.
         cache_data : bool, optional
             If set to `True`, the first call of this method will store the
             calculated data table in attribute self._data_raw
@@ -246,7 +246,7 @@ class GaussHermite(Kinematics, data.Integrated):
         if apply_systematic_error:
             # construct uncertainties
             uncertainties = np.zeros((self.n_apertures, number_gh))
-            # uncertainties on h1,h2 from vdMarel + Franx 93
+            # uncertainties on h1,h2 from vdMarel + Franx 93, ApJ 407,525
             uncertainties[:, 0] = gh_data['dv'] / np.sqrt(2) / gh_data['sigma']
             uncertainties[:, 1] = gh_data['dsigma']/np.sqrt(2)/gh_data['sigma']
             # uncertainties h3, h4, etc... are taken from gh_data table
@@ -588,7 +588,7 @@ class GaussHermite(Kinematics, data.Integrated):
         """Calcuate GH expansion coeffients given an LOSVD
 
         Expand LOSVD around a given v_mu and v_sig using eqn 7 of
-        vd Marel & Franx 93
+        vd Marel & Franx 93, ApJ 407,525
 
         Parameters
         ----------
@@ -678,7 +678,7 @@ class GaussHermite(Kinematics, data.Integrated):
             observed_values[:, i - 1] = gh_data[f'h{i}']
         # construct uncertainties
         uncertainties = np.zeros_like(observed_values)
-        # uncertainties on h1,h2 from vdMarel + Franx 93
+        # uncertainties on h1,h2 from vdMarel + Franx 93, ApJ 407,525
         uncertainties[:, 0] = gh_data['dv']
         uncertainties[:, 1] = gh_data['dsigma']
         # uncertainties h3, h4, etc... are taken from data table

--- a/dynamite/orblib.py
+++ b/dynamite/orblib.py
@@ -663,7 +663,7 @@ class LegacyOrbitLibrary(OrbitLibrary):
         error_msg = 'must have odd number of velocity bins for all kinematics'
         assert np.all(np.array(hist_bins) % 1==0), error_msg
         self.logger.debug('...checks ok.')
-        n_apertures = [len(k.data) for k in stars.kinematic_data]
+        n_apertures = [k.n_spatial_bins for k in stars.kinematic_data]
         # get index linking  kinematic set to aperture
         # kin_idx_per_ap[i] = N <--> aperture i is from kinematic set N
         kin_idx_per_ap = [np.zeros(n_apertures[i], dtype=int)+i

--- a/dynamite/plotter.py
+++ b/dynamite/plotter.py
@@ -487,9 +487,9 @@ class Plotter():
 
         """
         # get the data
-        stars = \
-          self.system.get_component_from_class(physys.TriaxialVisibleComponent)
+        stars = self.system.get_unique_triaxial_visible_component()
         kin_set = stars.kinematic_data[kin_set]
+        kin_data = kin_set.get_data()
         # helper function to decide which losvds to plot
         def dissimilar_subset_greedy_search(distance_matrix, target_size):
             """Greedy algorithm to find dissimilar subsets
@@ -520,11 +520,11 @@ class Plotter():
         # helper function to get positions of a regular 3x3 grid on the map
         def get_coords_of_regular_3by3_grid():
             # get range of x and y values
-            minx = np.min(kin_set.data['xbin'])
-            maxx = np.max(kin_set.data['xbin'])
+            minx = np.min(kin_data['xbin'])
+            maxx = np.max(kin_data['xbin'])
             x = np.array([minx, maxx])
-            miny = np.min(kin_set.data['ybin'])
-            maxy = np.max(kin_set.data['ybin'])
+            miny = np.min(kin_data['ybin'])
+            maxy = np.max(kin_data['ybin'])
             y = np.array([miny, maxy])
             x, y = kin_set.convert_to_plot_coords(x, y)
             # get 3 evenly spaced coords in x and y
@@ -575,8 +575,8 @@ class Plotter():
             return threshold
         # helper function to reorder the plotted LOSVDs into a sensible order
         def reorder_losvds(idx_to_plot):
-            x = kin_set.data['xbin'][idx_to_plot]
-            y = kin_set.data['ybin'][idx_to_plot]
+            x = kin_data['xbin'][idx_to_plot]
+            y = kin_data['ybin'][idx_to_plot]
             x, y = kin_set.convert_to_plot_coords(x, y)
             xg, yg = get_coords_of_regular_3by3_grid()
             # get distance between plot positions and regular grid
@@ -599,13 +599,13 @@ class Plotter():
         # normalise LOSVDs to same scale at data, i.e. summing to 1
         losvd_model = (losvd_model.T/np.sum(losvd_model, 1)).T
         # get chi2's
-        chi2_per_losvd_bin = losvd_model - kin_set.data['losvd']
-        chi2_per_losvd_bin = chi2_per_losvd_bin/kin_set.data['dlosvd']
+        chi2_per_losvd_bin = losvd_model - kin_data['losvd']
+        chi2_per_losvd_bin = chi2_per_losvd_bin/kin_data['dlosvd']
         chi2_per_losvd_bin = chi2_per_losvd_bin**2.
         chi2_per_apertur = np.sum(chi2_per_losvd_bin, 1)
-        reduced_chi2_per_apertur = chi2_per_apertur/kin_set.data.meta['nvbins']
+        reduced_chi2_per_apertur = chi2_per_apertur/kin_data.meta['nvbins']
         # pick a subset of 9 LOSVDs to plot which are not similar to one another
-        dist = 1.*kin_set.data['losvd']
+        dist = 1.*kin_data['losvd']
         dist = dist[:,np.newaxis,:] - dist[np.newaxis,:,:]
         dist = np.sum(dist**2., 2)**0.5
         idx_to_plot, _ = dissimilar_subset_greedy_search(dist, 9)
@@ -666,14 +666,14 @@ class Plotter():
         mean_chi2r = np.mean(reduced_chi2_per_apertur)
         ax_chi2.set_title(f'$\chi^2_r={mean_chi2r:.2f}$')
         # plot locations of LOSVDs
-        x = kin_set.data['xbin'][idx_to_plot]
-        y = kin_set.data['ybin'][idx_to_plot]
+        x = kin_data['xbin'][idx_to_plot]
+        y = kin_data['ybin'][idx_to_plot]
         x, y = kin_set.convert_to_plot_coords(x, y)
         ax_chi2.plot(x, y, 'o', ms=15, c='none', mec='0.2')
         for i, (x0,y0) in enumerate(zip(x,y)):
             ax_chi2.text(x0, y0, f'{i+1}', ha='center', va='center')
         # plot LOSVDs
-        varr = kin_set.data.meta['vcent']
+        varr = kin_data.meta['vcent']
         for i, (idx0, ax0) in enumerate(zip(idx_to_plot, ax_losvds)):
             col = (reduced_chi2_per_apertur[idx0]-vmin)/(vmax-vmin)
             col = cmap(col)
@@ -682,13 +682,13 @@ class Plotter():
                      bbox = dict(boxstyle=f"circle", fc=col, alpha=0.5)
                     )
             dat_line, = ax0.plot(varr,
-                                 kin_set.data['losvd'][idx0],
+                                 kin_data['losvd'][idx0],
                                  ls=':',
                                  color=color_dat)
             dat_band = ax0.fill_between(
                 varr,
-                kin_set.data['losvd'][idx0]-kin_set.data['dlosvd'][idx0],
-                kin_set.data['losvd'][idx0]+kin_set.data['dlosvd'][idx0],
+                kin_data['losvd'][idx0]-kin_data['dlosvd'][idx0],
+                kin_data['losvd'][idx0]+kin_data['dlosvd'][idx0],
                 alpha=0.2,
                 color=color_dat,
                 )

--- a/dynamite/weight_solvers.py
+++ b/dynamite/weight_solvers.py
@@ -670,7 +670,7 @@ class NNLS(WeightSolver):
         idx_ap_start = 0
         for (kins, orb_losvd) in kins_and_orb_losvds:
             # pick out the projected masses for this kinematic set
-            n_ap = len(kins.data)  # OK for both GaussHermite and BayesLOSVD
+            n_ap = kins.n_spatial_bins  # OK for both GaussHermite & BayesLOSVD
             idx_ap_end = idx_ap_start + n_ap
             prj_mass_i = self.projected_masses[idx_ap_start:idx_ap_end]
             idx_ap_start += n_ap
@@ -725,8 +725,9 @@ class NNLS(WeightSolver):
         if type(kins) is not dyn_kin.GaussHermite:
             return orb_gh
         orb_mu_v = orb_losvd.get_mean()
-        obs_mu_v = kins.data['v']
-        obs_sig_v = kins.data['sigma']
+        kins_data = kins.get_data(self.settings, apply_systematic_error=False)
+        obs_mu_v = kins_data['v']
+        obs_sig_v = kins_data['sigma']
         delta_v = np.abs(orb_mu_v - obs_mu_v)
         condition1 = (np.abs(obs_mu_v)/obs_sig_v > 1.5)
         condition2 = (delta_v/obs_sig_v > 3.0)


### PR DESCRIPTION
This PR minimizes direct access to the `Kinematics.data` attribute and replacing it by calling the `Kinematics.get_data(...)` method.

Rationale:
- For GH kinematics, the attribute `Kinematics.data` contains the input data as read from disk, whereas `Kinematics.get_data(...)` (a) always returns the number of GH coefficients `number_GH` specified in the configuration file and (b) if instructed, applies the systematic errors `GH_sys_err` specified in the configuration file.
- For other kinematics (currently `BayesLOSVD`), `.get_data()` returns a deep copy of the kinematics data.
- For consistency,` Kinematics.get_data()` should be used across DYNAMITE whenever kinematics data is accessed.

Notes:
- If 'dummy kinematics objects' are required, directly accessing the `.data` attribute will still be necessary (such as in `weight_solver.py` lines 189+ and `analysis.py` line 558). Is this reason enough to implement an option to instantiate a Kinematics object with the underlying data passed as an astropy table instead of a filename?
- Implemented a new attribute `Kinematics.n_spatial_bins` that can be used independent of the Kinematics type. For `GaussHermite`, it is the same as `.n_apertures`.

Tested with `test_nnls.py` and `test_notebooks.py`.

Closes #337.