### PR TITLE
Fixed a bug in retrofitting kinmapchi2 in old all_models tables.

### DIFF
--- a/docs/more_info/changelog.rst
+++ b/docs/more_info/changelog.rst
@@ -4,6 +4,7 @@
 Change Log
 ****************
 
+- Bugfix: fixed a bug in retrofitting kinmapchi2 in old all_models tables.
 - Improvement: removed deprecated silent option from config reader.
 - Improvement: the Plotter's new optional argument ``dpi`` (default: 100) allows to change the resolution of all saved figures except the kinematic maps (always 300 dpi).
 - Improvement: the beta plots now work for all implemented weight solvers.

--- a/dynamite/config_reader.py
+++ b/dynamite/config_reader.py
@@ -479,6 +479,7 @@ class Configuration(object):
         self.all_models = model.AllModels(config=self)
         logger.info('Instantiated AllModels object')
         logger.debug(f'AllModels:\n{self.all_models.table}')
+        self.all_models.update_model_table()
 
         # self.backup_config_file(reset=False)
 


### PR DESCRIPTION
When reading an old all_models table which does not have the `kinmapchi2` column, the column was added but calculating the `kinmapchi2` values did not work (silently...). This is fixed in this PR which - as discussed in a recent hack session - has been extracted from PR #322 for quicker merging. Until then, #322 will remain demoted to draft.

Remark:
Separated reading an existing all_models table (`AllModels.read_model_table()`) from updating it (`AllModels.update_model_table()`) to avoid problems with the configuration object (`config_reader.py` takes care of this).

Successfully tested with `test_nnls.py` and both weight solvers to verify that a deleted `kinmapchi2` column gets re-added upon reading the all models table. Also, `test_notebooks.sh` succeeds.

Test suggestion:
1. Run the original `test_nnls.py`.
2. In `test_nnls.py:36`, set `reset_existing_output=False`.
3. In `all_models.ecsv`, delete the `kinmapchi2` column (headline + 3 values) and its entry in the header (entire line 14).
4. Re-run `test_nnls.py` and inspect the output: `all_models.ecsv` should now have the `kinmapchi2` column with the correct values again.

This test should also succeed when changing the weight solver (legacy weight solver <-> Python NNLS) in the config file between deleting and re-adding the `kinmapchi2` column (with some warnings because the config file will now differ from the one uses when initially creating `all_models.ecsv`).