### PR TITLE
Bin and apertures check

### DIFF
--- a/docs/more_info/changelog.rst
+++ b/docs/more_info/changelog.rst
@@ -7,6 +7,7 @@ Change Log
 Version: 4.2
 ================
 
+- Improvement: improved checks and error messages for velocity and spatial bin input data inconsistencies.
 - Improvement: if ``number_GH`` in the config file is larger than the kinematic order of the observed data, then DYNAMITE ensures that the corresponding systematic errors are > 0.
 - Bugfix: fixed a bug in the kinematics errors (affects NNLS solves).
 - New feature: Gauss-Hermite kinematic maps can now be plotted for any number of Gauss-Hermite coefficients.

--- a/docs/more_info/changelog.rst
+++ b/docs/more_info/changelog.rst
@@ -4,6 +4,7 @@
 Change Log
 ****************
 
+- Improvement: improved checks and error messages for velocity and spatial bin input data inconsistencies.
 - Improvement: save disk space by cleaning up decompressed files after a crash and removing unused legacy file nn_orbmat.out after solving.
 - Improvement: stability fix in MGE: if q>0.9999 it will be set to 0.9999 (before, it was 0.99999).
 - Bugfix: the chi2 plot now shows correct axis ticks for log quantities.
@@ -13,7 +14,6 @@ Change Log
 Version: 4.2
 ================
 
-- Improvement: improved checks and error messages for velocity and spatial bin input data inconsistencies.
 - Improvement: if ``number_GH`` in the config file is larger than the kinematic order of the observed data, then DYNAMITE ensures that the corresponding systematic errors are > 0.
 - Bugfix: fixed a bug in the kinematics errors (affects NNLS solves).
 - New feature: Gauss-Hermite kinematic maps can now be plotted for any number of Gauss-Hermite coefficients.

--- a/dynamite/data.py
+++ b/dynamite/data.py
@@ -175,7 +175,7 @@ class Integrated(Data):
         i_var = int(i_var[0])
         grid = np.ravel(np.array(grid))
         if not (nx * ny == i_var == len(grid)):
-            txt = f'Number of apertures do not match: {nx}*{ny}={nx*ny} ' \
+            txt = f'Numbers of apertures do not match: {nx}*{ny}={nx*ny} ' \
                   f'({self.aperturefile}), {i_var} ({self.binfile}), ' \
                   f'{len(grid)} (bin data points in {self.binfile}).'
             self.logger.error(txt)
@@ -183,7 +183,7 @@ class Integrated(Data):
         self.logger.debug(f'{self.aperturefile} and {self.binfile} read.')
         n_bins_kinem = self.data[-1][0] + (1 if self.data[0][0] == 0 else 0)
         if not (n_bins_kinem == len(self.data) == max(grid)):
-            txt = f'Number of kinematic bins does not match: {len(self.data)}'\
+            txt = f'Numbers of kinematic bins do not match: {len(self.data)}'\
                   f' (length of {self.datafile}), {n_bins_kinem} (last id in '\
                   f'{self.datafile}), max number {max(grid)} in {self.binfile}.'
             self.logger.error(txt)

--- a/dynamite/data.py
+++ b/dynamite/data.py
@@ -182,9 +182,10 @@ class Integrated(Data):
             raise ValueError(txt)
         self.logger.debug(f'{self.aperturefile} and {self.binfile} read.')
         n_bins_kinem = self.data[-1][0]
-        if n_bins_kinem != max(grid):
-            txt = f'Number of kinematic bins {n_bins_kinem} ({self.datafile})'\
-                  f' does not match max number {max(grid)} in {self.binfile}.'
+        if not (n_bins_kinem == len(self.data) == max(grid)):
+            txt = f'Number of kinematic bins does not match: {len(self.data)}'\
+                  f' (length of {self.datafile}), {n_bins_kinem} (last id in '\
+                  f'{self.datafile}), max number {max(grid)} in {self.binfile}.'
             self.logger.error(txt)
             raise ValueError(txt)
         self.logger.debug(f'Number of vbins in {self.datafile}, '

--- a/dynamite/data.py
+++ b/dynamite/data.py
@@ -181,7 +181,7 @@ class Integrated(Data):
             self.logger.error(txt)
             raise ValueError(txt)
         self.logger.debug(f'{self.aperturefile} and {self.binfile} read.')
-        n_bins_kinem = self.data[-1][0]
+        n_bins_kinem = self.data[-1][0] + (1 if self.data[0][0] == 0 else 0)
         if not (n_bins_kinem == len(self.data) == max(grid)):
             txt = f'Number of kinematic bins does not match: {len(self.data)}'\
                   f' (length of {self.datafile}), {n_bins_kinem} (last id in '\

--- a/dynamite/data.py
+++ b/dynamite/data.py
@@ -1,6 +1,6 @@
+import logging
 from astropy.io import ascii
 from astropy.table import Table
-import logging
 import numpy as np
 from plotbin import display_pixels
 
@@ -174,6 +174,21 @@ class Integrated(Data):
         str_head = str(str_head[0])
         i_var = int(i_var[0])
         grid = np.ravel(np.array(grid))
+        if not (nx * ny == i_var == len(grid)):
+            txt = f'Number of apertures do not match: {nx}*{ny}={nx*ny} ' \
+                  f'({self.aperturefile}), {i_var} ({self.binfile}), ' \
+                  f'{len(grid)} (bin data points in {self.binfile}).'
+            self.logger.error(txt)
+            raise ValueError(txt)
+        self.logger.debug(f'{self.aperturefile} and {self.binfile} read.')
+        n_bins_kinem = self.data[-1][0]
+        if n_bins_kinem != max(grid):
+            txt = f'Number of kinematic bins {n_bins_kinem} ({self.datafile})'\
+                  f' does not match max number {max(grid)} in {self.binfile}.'
+            self.logger.error(txt)
+            raise ValueError(txt)
+        self.logger.debug(f'Number of vbins in {self.datafile}, '
+                          f'{self.binfile} validated.')
         # bins start counting at 1 in fortran and at 0 in idl:
         grid = grid - 1
         # Only select the pixels that have a bin associated with them.


### PR DESCRIPTION
Upon reading the aperture, bins, and kinematics files, DYNAMITE now checks for
- consistent number of velocity (kinematics) bins between the kinematics and bins input files
- consistent number of spatial bins between the aperture and bins input files

Tested with `test_nnls.py` (with provoking errors in all three input files) and "all passed" with `test_notebooks.sh`.

@sthater: perhaps you and/or Julia can test this with your erroneous data and verify that you get meaningful error messages.

Closes #370.