### PR TITLE
Legacy nnls file cleanup

### DIFF
--- a/docs/more_info/changelog.rst
+++ b/docs/more_info/changelog.rst
@@ -4,6 +4,8 @@
 Change Log
 ****************
 
+- Improvement: ``LegacyWeightSolver`` is now DEPRECATED and will be removed along with GALAHAD in a future version of DYNAMITE. Use weight solver ``type: NNLS`` instead if you can.
+
 Version: 4.2
 ================
 

--- a/docs/more_info/changelog.rst
+++ b/docs/more_info/changelog.rst
@@ -4,7 +4,7 @@
 Change Log
 ****************
 
-- Improvement: ``LegacyWeightSolver`` is now DEPRECATED and will be removed along with GALAHAD in a future version of DYNAMITE. Use weight solver ``type: NNLS`` instead if you can.
+- Improvement: ``LegacyWeightSolver`` is now DEPRECATED and will be removed along with GALAHAD in a future version of DYNAMITE. Use weight solver ``type: "NNLS"`` instead if you can.
 
 Version: 4.2
 ================

--- a/dynamite/weight_solvers.py
+++ b/dynamite/weight_solvers.py
@@ -26,7 +26,9 @@ class WeightSolver(object):
         model directory with the ml extension
     CRcut : Bool, default False
         whether to use the `CRcut` solution for the counter-rotating orbit
-        problem. See Zhu et al. 2018 for more.
+        problem. See Zhu et al. 2018 for more. If `CRcut` is given in the
+        configuration file's weight solver settings (which is normally the
+        case), this parameter is ignored.
 
     """
 

--- a/dynamite/weight_solvers.py
+++ b/dynamite/weight_solvers.py
@@ -278,10 +278,10 @@ class LegacyWeightSolver(WeightSolver):
             chi2_kinmap = results.meta['chi2_kinmap']
         else:
             # If legacy result files do not exist, run weight solving.
-            check1 = os.path.isfile(self.fname_nn_kinem)
-            check2 = os.path.isfile(self.fname_nn_nnls)
-            check3 = os.path.isfile(self.direc_with_ml + 'nn_orbmat.out')
-            if not check1 or not check2 or not check3:
+            check = (os.path.isfile(self.fname_nn_kinem) and
+                     os.path.isfile(self.fname_nn_nnls) and
+                     os.path.isfile(self.direc_with_ml + 'nn_orbmat.out'))
+            if ignore_existing_weights or not check:
                 # set the current directory to the directory in which
                 # the models are computed
                 cur_dir = os.getcwd()
@@ -320,7 +320,7 @@ class LegacyWeightSolver(WeightSolver):
                 # delete existing .yaml files and copy current config file
                 # into model directory
                 self.config.copy_config_file(self.direc_with_ml)
-            else:
+            else:  # If legacy output files exist, just create the weight file
                 self.logger.info("Reading NNLS solution from existing legacy "
                                  "output and converting to weights file.")
             # Now the legacy result files exist -> read, calculate
@@ -336,6 +336,8 @@ class LegacyWeightSolver(WeightSolver):
             results.write(self.weight_file,
                           format='ascii.ecsv',
                           overwrite=True)
+            # clean up
+            os.remove(self.direc_with_ml + 'nn_orbmat.out')
         return weights, chi2_tot, chi2_kin, chi2_kinmap
 
     def write_executable_for_weight_solver(self):


### PR DESCRIPTION
Based on today's discussion, this PR implements:
- `LegacyWeightSolver.solve()` deletes the `nn.orbmat.out` file after a successful solve.
- Add LegacyWeightSolver deprecation info to the log file and the changelog in the docs.

Idea for testing: run any set of models with weight solver `type: "LegacyWeightSolver"` and verify that the file `nn.orbmat.out` is not in the model directory.

Closes #377