### PR TITLE
Save disk space by cleaning up decompressed files independently from legacy script succeeding or not

### DIFF
--- a/docs/more_info/changelog.rst
+++ b/docs/more_info/changelog.rst
@@ -4,7 +4,7 @@
 Change Log
 ****************
 
-- Improvement: save disk space by cleaning up decompressed files after a crash and removing unused legacy files nn_orbmat.out after solving.
+- Improvement: save disk space by cleaning up decompressed files after a crash and removing unused legacy file nn_orbmat.out after solving.
 - Improvement: ``LegacyWeightSolver`` is now DEPRECATED and will be removed along with GALAHAD in a future version of DYNAMITE. Use weight solver ``type: "NNLS"`` instead if you can.
 
 Version: 4.2

--- a/docs/more_info/changelog.rst
+++ b/docs/more_info/changelog.rst
@@ -4,6 +4,7 @@
 Change Log
 ****************
 
+- Improvement: save disk space by cleaning up decompressed files after a crash and removing unused legacy files nn_orbmat.out after solving.
 - Improvement: ``LegacyWeightSolver`` is now DEPRECATED and will be removed along with GALAHAD in a future version of DYNAMITE. Use weight solver ``type: "NNLS"`` instead if you can.
 
 Version: 4.2

--- a/dynamite/weight_solvers.py
+++ b/dynamite/weight_solvers.py
@@ -283,10 +283,11 @@ class LegacyWeightSolver(WeightSolver):
             chi2_kin = results.meta['chi2_kin']
             chi2_kinmap = results.meta['chi2_kinmap']
         else:
+            fname_nn_orbmat = self.direc_with_ml + 'nn_orbmat.out'
             # If legacy result files do not exist, run weight solving.
             check = (os.path.isfile(self.fname_nn_kinem) and
                      os.path.isfile(self.fname_nn_nnls) and
-                     os.path.isfile(self.direc_with_ml + 'nn_orbmat.out'))
+                     os.path.isfile(fname_nn_orbmat))
             if ignore_existing_weights or not check:
                 # set the current directory to the directory in which
                 # the models are computed
@@ -306,6 +307,11 @@ class LegacyWeightSolver(WeightSolver):
                                    stdout=subprocess.PIPE,
                                    stderr=subprocess.STDOUT,
                                    shell=True)
+                # clean up decompressed files
+                for f_name in [f'datfil/orblib_{self.ml}.dat',
+                               f'datfil/orblibbox_{self.ml}.dat']:
+                    if os.path.isfile(f_name):
+                        os.remove(f_name)
                 log_file = f'Logfile: {self.direc_no_ml+logfile}.'
                 if not p.stdout.decode("UTF-8"):
                     self.logger.info(f'...done, NNLS problem solved - {cmdstr}'
@@ -342,7 +348,8 @@ class LegacyWeightSolver(WeightSolver):
                           format='ascii.ecsv',
                           overwrite=True)
             # clean up
-            os.remove(self.direc_with_ml + 'nn_orbmat.out')
+            if os.path.isfile(fname_nn_orbmat):
+                os.remove(fname_nn_orbmat)
         return weights, chi2_tot, chi2_kin, chi2_kinmap
 
     def write_executable_for_weight_solver(self):
@@ -386,8 +393,6 @@ class LegacyWeightSolver(WeightSolver):
                            self.legacy_directory +
                            f'/triaxnnls_noCRcut < {nn}.in >> {nn}ls.log '
                            '|| exit 1\n')
-        txt_file.write(f'rm datfil/orblib_{self.ml}.dat' + '\n')
-        txt_file.write(f'rm datfil/orblibbox_{self.ml}.dat' + '\n')
         txt_file.close()
         return cmdstr
 


### PR DESCRIPTION
Save disk space by cleaning up decompressed files independently from legacy Fortran code succeeding or crashing.
- Moved deleting the decompressed files from the shell script to the method `LegacyWeightSolver.solve()` so deletion takes place independently of any errors that might occur in the shell script and/or the legacy executables called by that script.

Safer removal of `nn_orbmat.out`: check for existing file before deleting.

Suggestion for testing:
1. Provoke an error in `LegacyWeightSolver.solve()`, right after executing the shell script (this simulates a script error). For example, this can be done in `weight_solvers.py` by changing line 316 from `if not p.stdout.decode("UTF-8"):` to `if not p.stdout.decode("UTF-8") and False:`.
2. Run any example using the `LegacyWeightSolver`.
3. Verify that after DYNAMITE crashes, there are no surviving `orblib_*.dat` files in any of the `datfil/` folders (those would be the uncompressed files).
4. Optional: in line 314, change `os.remove(f_name)` to `pass` and re-run. The `orblib_*.dat` files should still be there in the `datfil/` folder(s) after DYNAMITE crashes.

So far, tested successfully with `test_nnls.py` (after changing to the `LegacyWeightSolver` in its config file).