### PR TITLE
Bayes LOSVD fluxes fix

### DIFF
--- a/docs/more_info/changelog.rst
+++ b/docs/more_info/changelog.rst
@@ -4,6 +4,7 @@
 Change Log
 ****************
 
+- Bugfix: fix a crash when creating the BayesLOSVD kinematics file in rare cases where the completed bins were determined incorrectly.
 - Improvement: save disk space by cleaning up decompressed files after a crash and removing unused legacy file nn_orbmat.out after solving.
 - Improvement: stability fix in MGE: if q>0.9999 it will be set to 0.9999 (before, it was 0.99999).
 - Bugfix: the chi2 plot now shows correct axis ticks for log quantities.


### PR DESCRIPTION
Fix a crash when creating the BayesLOSVD kinematics file in rare cases where the completed bins were determined incorrectly.

Here is what happened in method `BayesLOSVD.write_losvds_to_ecsv_format()`:
- The input file (hdf5) is read into dictionary `result`, assuming that the completed bins are associated to the dictionary keys with type integer (`completed_bins = [i for i in result.keys() if type(i) is int]`).
- Later in the code, the data is put into an astropy table `data` that has length `len(completed_bins)` and the statement `data['bin_flux'] = result['bin_flux']` is used to assign the fluxes from the hdf5 file to the table. While this works for most users, in at least one case this statement failed with error "Inconsistent data column lengths".
- Diagnosis: in that particular case, there was a discrepancy between `len(completed_bins)` and the number of entries in `result['bin_flux']`.
- Solution: Accepting only `result['bin_flux']` entries that actually correspond to a valid `completed_bins` entry worked for this case, so the proposed solution is to replace the violating assignment `data['bin_flux'] = result['bin_flux']` by including it in the for loop starting in line 1056. This ensures that only `result['bin_flux']` values that actually correspond to a `completed_bins` entry are copied.

Testing: tested with tutorial '4. BayesLOSVD and DYNAMITE'.

@liquidreams: Can you confirm that this solution works for you? As far as I remember you implemented it locally a while ago.
@prashjet: would be great if you had a look at the code ;-)

Closes #360.

Cheers,
Thomas