### PR TITLE
Improved data preparation

### DIFF
--- a/docs/more_info/changelog.rst
+++ b/docs/more_info/changelog.rst
@@ -4,6 +4,7 @@
 Change Log
 ****************
 
+- New feature: ``data_prep/generate_kin_input.py`` implements reading NIFS kinematics with an arbitrary number of GH moments.
 - Improvement: save disk space by cleaning up decompressed files after a crash and removing unused legacy file nn_orbmat.out after solving.
 - Improvement: stability fix in MGE: if q>0.9999 it will be set to 0.9999 (before, it was 0.99999).
 - Bugfix: the chi2 plot now shows correct axis ticks for log quantities.

--- a/dynamite/data_prep/generate_kin_input.py
+++ b/dynamite/data_prep/generate_kin_input.py
@@ -310,7 +310,7 @@ def create_kin_input(galaxy, file, dyn_model_dir, expr='', angle_deg=0, ngh=4,
 
     if kin_input in ['CALIFA', 'ATLAS3D']:
         data = table.Table()
-        data['v'] = vel
+        data['v'] = vel - np.median(vel)  # not done in califa and atlas3d read
         data['dv'] = dvel
         data['sigma'] = sig
         data['dsigma'] = dsig

--- a/dynamite/data_prep/generate_kin_input.py
+++ b/dynamite/data_prep/generate_kin_input.py
@@ -333,14 +333,20 @@ def create_kin_input(galaxy, file, dyn_model_dir, expr='', angle_deg=0,
         print('Vels plot: {0}, {1}, {2}'.format(vmax, smin, smax))
 
         plot_rows = (n_gh - 1) // 6 + 1
-        if n_gh == 4:
+        if n_gh <= 4:
             plot_cols = 4
-            fig, ax = plt.subplots(1, 4, figsize=(18,4))
+            figsize = (18, 4)
         else:
             plot_cols = 6
-            fig, ax = plt.subplots(plot_rows,
-                                   plot_cols,
-                                   figsize=(25, 5 * plot_rows))
+            figsize = (25, 5 * plot_rows)
+        fig, ax = plt.subplots(plot_rows, plot_cols, figsize=figsize)
+        if n_gh % plot_cols > 0:  # remove axes from empty subplots
+            for col in range(n_gh % plot_cols, plot_cols):
+                if plot_rows == 1:
+                    ax[col].set_axis_off()
+                else:
+                    ax[plot_rows - 1, col].set_axis_off()
+
         plt.subplot(plot_rows,plot_cols,1)
         plt.title('Velocity [km/s]')
         plt.xlabel('arcsec', fontsize=10)

--- a/dynamite/data_prep/generate_kin_input.py
+++ b/dynamite/data_prep/generate_kin_input.py
@@ -231,7 +231,8 @@ def kin_file(directory,expr,data):
 
 
 #### main routine ######
-def create_kin_input(galaxy, file, dyn_model_dir, expr='', angle_deg=0, ngh=4,
+def create_kin_input(galaxy, file, dyn_model_dir, expr='', angle_deg=0,
+                     ngh='all',
                      pointsym=0, bisym=0, xoffset=0, yoffset=0, voffset=0,
                      fit_PA=False, kin_input=0, files=True, plot=True):
     """
@@ -245,16 +246,20 @@ def create_kin_input(galaxy, file, dyn_model_dir, expr='', angle_deg=0, ngh=4,
 
     #read in binned kinematics, this needs to be changed by the user
     if kin_input == 'CALIFA':
+        if ngh == 'all':
+            ngh = 4
         binNum,xp,yp,flux,vel,sig,h3,h4,dvel,dsig,dh3,dh4,xbin,ybin=read_califa(file)
 
     elif kin_input == 'ATLAS3D':
+        if ngh == 'all':
+            ngh = 4
         binNum,xp,yp,flux,vel,sig,h3,h4,dvel,dsig,dh3,dh4,xbin,ybin=read_atlas3d(file)
 
     elif kin_input == 'USER':
         binNum, xp, yp, data = read_kinematics_user(file)
 
     elif kin_input == 'NIFS':
-        binNum, xp, yp, data = read_kinematics_nifs(file, idl=True)
+        binNum, xp, yp, data = read_kinematics_nifs(file, n_gh=ngh, idl=True)
 
     if kin_input in ['CALIFA', 'ATLAS3D']:
         data = table.Table()


### PR DESCRIPTION
Based on Julia's code, `data_prep/generate_kin_input.py` now implements reading NIFS kinematics with any number of GH moments. The features are:
- `read_kinematics_nifs()` reads the NIFS kinematics data and the binning data files and returns the kinematics data suitable for `create_kin_input()`.
- plotting is adapting to the number of GH moments

Open question: So far, the only well-documented method in `data_prep/generate_kin_input.py` is `read_kinematics_nifs()`. Shall we go the extra mile and make the whole code prettier and better documented?

This has been tested with #GH=6 data (non public) and tutorial `1_data_prep_for_gauss_hermite` to make sure CALIFA and ATLAD3D still work as expected.

Closes #303.