### PR TITLE
Use overall chi2 improvement (instead of improvement over previous chi2 only) when checking min_delta_chi2 criterion

### DIFF
--- a/dynamite/parameter_space.py
+++ b/dynamite/parameter_space.py
@@ -587,14 +587,21 @@ class ParameterGenerator(object):
                 models0 = self.current_models.table[mask]
                 last_chi2 = np.nanmin(models0[self.chi2])
                 last_iter -= 1
-            previous_chi2 = np.nan
-            while np.isnan(previous_chi2): # look for non-nan (kin)chi2 value
-                if last_iter < 0:
-                    return
-                mask = self.current_models.table['which_iter'] == last_iter
-                models1 = self.current_models.table[mask]
-                previous_chi2 = np.nanmin(models1[self.chi2])
-                last_iter -= 1
+            # previous_chi2 = np.nan
+            # while np.isnan(previous_chi2): # look for non-nan (kin)chi2 value
+            #     if last_iter < 0:
+            #         return
+            #     mask = self.current_models.table['which_iter'] == last_iter
+            #     models1 = self.current_models.table[mask]
+            #     previous_chi2 = np.nanmin(models1[self.chi2])
+            #     last_iter -= 1
+            if last_iter < 0:
+                return
+            mask = self.current_models.table['which_iter'] <= last_iter
+            models1 = self.current_models.table[mask]
+            previous_chi2 = np.nanmin(models1[self.chi2])
+            if np.isnan(previous_chi2):
+                return
             # Don't use abs() so we stop on increasing chi2 values, too:
             delta_chi2 = previous_chi2 - last_chi2
             if self.min_delta_chi2_rel:


### PR DESCRIPTION
#391 reports a crash in `ParameterGenerator.check_specific_stopping_critera()` in a case where chi2 does not significantly improve over several hundred models (iterations?).

What may be happening based on the information provided:
- The problem occurs in the method `ParameterGenerator.check_specific_stopping_critera()` that checks for each iteration whether the specific stopping criteria have been met. This is the case if the best $\chi^2$ value of the last iteration does not improve the best $\chi^2$ value of the preceding iteration by at least `min_delta_chi2_rel` or `min_delta_chi2_abs` (depending on the setting in the configuration file). Looking at the $\chi^2$ vs. model id plot provided in #391, the $\chi^2$ values do not seem to really improve between model 180 to 540 or so.
- It may be that something like the following is happening: when checking for the best $\chi^2$ of the preceding iteration, that iteration may be empty (i.e., does not contain any models). Consequently, calculating the minimum $\chi^2$ of no models fails and throws the error. However, I don’t fully understand why this does not happen in the previous iteration, where the error should be thrown in line 588 instead of 596 of `parameter_space.py`…

In this PR, the method `ParameterGenerator.check_specific_stopping_critera()` now compares the last iteration's minimum $\chi^2$ to the _overall_ minimum $\chi^2$ so far.

Dear @avichaturvedi, please try whether this PR solves your issue and let me know - many thanks!