### PR TITLE
Catch exceptions thrown by Python weight solving

### DIFF
--- a/docs/getting_started/code_overview.rst
+++ b/docs/getting_started/code_overview.rst
@@ -109,6 +109,7 @@ Comments on kinematics
 ----------------------
 
 LegacyWeightSolver can't be used with BayesLOSVD - use weight-solver type NNLS.
+In some cases, the weight solver ``type: "NNLS"`` ``nnls_solver: "scipy"`` may fail for some models if the SciPy version is >= 1.12. In such cases, it is recommended to use ``type: "NNLS"`` ``nnls_solver: "cvxopt"`` or to reinstall DYNAMITE with ``scipy<1.12`` in ``requirements.txt``.
 
 It is possible to simultaneously fit multiple sets of kinematics in DYNAMITE, which is only supported for Gauss Hermite kinematics. In that case, all input files should be placed in this directory::
 

--- a/docs/more_info/changelog.rst
+++ b/docs/more_info/changelog.rst
@@ -4,6 +4,7 @@
 Change Log
 ****************
 
+- Improvement: prevent DYNAMITE from crashing if NNLS weight solving fails.
 - Improvement: the Gauss Hermite kinematic maps new parameter value `cbar_lims='user'` allows user-defined velocity and velocity dispersion limits (see `Plotter.plot_kinematic_maps()`).
 - Improvement: reduced the main memory requirements of the Python NNLS solvers.
 - Bugfix: fix a crash when creating the BayesLOSVD kinematics file in rare cases where the completed bins were determined incorrectly.

--- a/dynamite/model_iterator.py
+++ b/dynamite/model_iterator.py
@@ -112,7 +112,7 @@ class ModelIterator(object):
         tuple of matplotlib.pyplot.figure:
             matplotlib.pyplot.figure: chi2 vs. model id plot
             matplotlib.pyplot.figure: chisquare plot
-            (matplotlib.pyplot.figure, str): kinematic maps of best model so 
+            (matplotlib.pyplot.figure, str): kinematic maps of best model so
             far, kinematics name
 
         """
@@ -144,11 +144,15 @@ class ModelIterator(object):
                 config.all_models.table[row]['kinchi2'] = kinchi2
                 config.all_models.table[row]['kinmapchi2'] = kinmapchi2
                 config.all_models.table[row]['time_modified'] = time
-                config.all_models.table[row]['weights_done'] = True
-                config.all_models.table[row]['all_done'] = True
+                if not all(np.isnan([chi2, kinchi2, kinmapchi2])):
+                    config.all_models.table[row]['weights_done'] = True
+                    config.all_models.table[row]['all_done'] = True
+                    self.logger.debug('Reattempting weight solving for model '
+                                      f'in row {i} successful.')
+                else:
+                    self.logger.info('Reattempting weight solving for model '
+                                     f'in row {i} failed.')
             config.all_models.save()
-            self.logger.debug('Reattempted weight solving for models in in rows'
-                             f' {rows_with_orbits_but_no_weights} successful.')
 
     def get_missing_weights(self, row):
         self.logger.debug(f'Reattempting weight solving for model {row}.')
@@ -435,7 +439,8 @@ class ModelInnerIterator(object):
                 orb_done = True
                 if get_weights:
                     weight_solver = mod.get_weights(orblib)
-                    wts_done = True
+                    if not np.isnan(mod.weights[0]):
+                        wts_done = True
                 else:
                     mod.chi2, mod.kinchi2, mod.kinmapchi2 \
                         = np.nan, np.nan, np.nan

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ cvxopt>=1.2.6
 h5py>=3.1.0
 lmfit
 matplotlib>=3.3.4
-numpy<1.25,>=1.21
+numpy>=1.21
 pafit>=2.0.8
 pathos>=0.2.7
 plotbin>=3.1.3


### PR DESCRIPTION
Proposed solution to issue #400:

This PR catches exceptions thrown by `scipy.optimize.nnls()` and in that case, sets the orbit weights and $\chi^2$ values to nan, does not create the weights file, sets `weights_done = False`, and logs a warning message, hinting towards using `cvxopt` (which does not have the problem). [For completeness, the same logic has been implemented in case `cvxopt` fails, although this does not seem to happen.]
 
- This solution is compatible with the existing implementation using older SciPy versions.
- By setting `weights_done = False`, a subsequent run with `reattempt_failures: True` and another weight solver (`cvxopt` or `scipy<1.12`) will retry weight solving and update the all_models table.
- It is expected that `scipy.optimize.nnls()` will further mature with future SciPy releases, so this solution should (hopefully) be future proof.
- Added information on this behavior in the docs (Overview -> Comments on kinematics).
- Remark: experimenting with the new `atol` argument of  `scipy.optimize.nnls()` did not help (instead of `Matrix is singular`, it produces `Maximum number of iterations reached` exceptions), apart from the code needing to distinguish between SciPy versions (which is a bit clunky).

Tests performed (with Python 3.10 and varying SciPy versions):
- Data provided by @juliala2504 (BayesLOSVD): SciPy 1.11.4 and SciPy 1.14.0 results are the same (> 5 identical digits in `chi2` and `kinchi2`).
- test_nnls.py: SciPy 1.11.4 and SciPy 1.14.0 results are the same (> 6 identical digits in `chi2`, `kinchi2`, and `kinmapchi2`).

If multiple users complain about scipy nnls problems (both `test_nnls.py` and `Tutorial 4. BayesLOSVD and DYNAMITE` run ok with the latest SciPy), we may still restrict `scipy<1.12` until further notice. As this will require periodic checking as SciPy versions keep coming this may not be the best solution, though...

Resolves #400 