### PR TITLE
Check for nan values in the kinematics and mges when first reading th…

### DIFF
--- a/docs/more_info/changelog.rst
+++ b/docs/more_info/changelog.rst
@@ -4,6 +4,7 @@
 Change Log
 ****************
 
+- Improvement: DYNAMITE now checks for nan values in the kinematics and mges when first reading the data
 - Improvement: the Gauss Hermite kinematic maps new parameter value `cbar_lims='user'` allows user-defined velocity and velocity dispersion limits (see `Plotter.plot_kinematic_maps()`).
 - Improvement: reduced the main memory requirements of the Python NNLS solvers.
 - Bugfix: fix a crash when creating the BayesLOSVD kinematics file in rare cases where the completed bins were determined incorrectly.

--- a/dynamite/data.py
+++ b/dynamite/data.py
@@ -25,22 +25,22 @@ class Data(object):
                  datafile=None,
                  input_directory=None
                  ):
+        self.logger = logging.getLogger(f'{__name__}.{__class__.__name__}')
         self.name = name
         if not hasattr(self, 'input_directory'):
             self.datafile = datafile
             self.input_directory = input_directory if input_directory else ''
             if datafile is not None:
                 self.data = ascii.read(self.input_directory+self.datafile)
-            self.logger = logging.getLogger(f'{__name__}.{__class__.__name__}')
-            self.logger.debug(f'Data {self.name} read from '
-                              f'{self.input_directory}{self.datafile}')
-            data_array = np.lib.recfunctions.structured_to_unstructured(
-                self.data.as_array())
-            if np.isnan(data_array).any():
-                txt = f'Input file {self.input_directory}{datafile} has nans'
-                self.logger.error(f'{txt} at: '
-                                  f'{np.argwhere(np.isnan(data_array))}.')
-                raise ValueError(txt)
+                self.logger.debug(f'Data {self.name} read from '
+                                  f'{self.input_directory}{self.datafile}')
+                data_array = np.lib.recfunctions.structured_to_unstructured(
+                    self.data.as_array())
+                if np.isnan(data_array).any():
+                    txt=f'Input file {self.input_directory}{datafile} has nans'
+                    self.logger.error(f'{txt} at: '
+                                      f'{np.argwhere(np.isnan(data_array))}.')
+                    raise ValueError(txt)
 
 
 class Discrete(Data):

--- a/dynamite/data.py
+++ b/dynamite/data.py
@@ -34,6 +34,13 @@ class Data(object):
             self.logger = logging.getLogger(f'{__name__}.{__class__.__name__}')
             self.logger.debug(f'Data {self.name} read from '
                               f'{self.input_directory}{self.datafile}')
+            data_array = np.lib.recfunctions.structured_to_unstructured(
+                self.data.as_array())
+            if np.isnan(data_array).any():
+                txt = f'Input file {self.input_directory}{datafile} has nans'
+                self.logger.error(f'{txt} at: '
+                                  f'{np.argwhere(np.isnan(data_array))}.')
+                raise ValueError(txt)
 
 
 class Discrete(Data):

--- a/dynamite/kinematics.py
+++ b/dynamite/kinematics.py
@@ -330,6 +330,10 @@ class GaussHermite(Kinematics, data.Integrated):
                              names=names,
                              dtype=dtype)
         self.logger.debug(f'File {filename} read (old format)')
+        if np.isnan(data).any():
+            txt = f'Input file {filename} has nans'
+            self.logger.error(f'{txt} at: {np.argwhere(np.isnan(data))}.')
+            raise ValueError(txt)
         return data
 
     def convert_file_from_old_format(self,
@@ -1004,6 +1008,11 @@ class BayesLOSVD(Kinematics, data.Integrated):
         for key,values in input_data.items():
             self.logger.debug(' - '+key)
             struct[key] = np.array(values)
+            if np.isnan(struct[key]).any():
+                txt = f'Input file {filename} has nans'
+                self.logger.error(f'{txt} at: '
+                                  f'{np.argwhere(np.isnan(struct[key]))}.')
+                raise ValueError(txt)
         if f.get("out") != None:
             self.logger.debug("# Loading Stan results:")
             output_data = f['out']
@@ -1013,7 +1022,13 @@ class BayesLOSVD(Kinematics, data.Integrated):
                 struct[int(idx)] = {}
                 for key,values in tmp.items():
                     self.logger.debug(' - ['+idx+'] '+key)
-                    struct[int(idx)][key] = np.array(values)
+                    v_array = np.array(values)
+                    struct[int(idx)][key] = v_array
+                    if np.isnan(v_array).any():
+                        txt = f'Input file {filename} has nans'
+                        self.logger.error(f'{txt} at: '
+                                          f'{np.argwhere(np.isnan(v_array))}.')
+                        raise ValueError(txt)
         self.logger.info("load_hdf5 is DONE")
         return struct
 

--- a/dynamite/mges.py
+++ b/dynamite/mges.py
@@ -59,6 +59,10 @@ class MGE(data.Data):
                             skip_header=1,
                             max_rows=n_cmp_mge,
                             names=['I', 'sigma', 'q', 'PA_twist'])
+        if np.isnan(dat).any():
+            txt = f'Input file {filename} has nans'
+            self.logger.error(f'{txt} at: {np.argwhere(np.isnan(dat))}.')
+            raise ValueError(txt)
         return dat
 
     def convert_file_from_old_format(self,


### PR DESCRIPTION
Check for nan values in the kinematics and mges when first reading the data.

Testing: please place a `nan` in the kinematics and/or mge input file(s) and run any model (e.g., `test_nnls.py`). Upon instantiating the kinematics (mge, resp.) objects, DYNAMITE should abort with an error pointing to the `nan` values.

Created to avoid hard to debug problems like the one reported in issue #402.
