### PR TITLE
Bugfix in ParameterGenerator.check_stopping_critera()

### DIFF
--- a/docs/getting_started/configuration.rst
+++ b/docs/getting_started/configuration.rst
@@ -301,7 +301,7 @@ Settings relevant for parameter search.
     - ``stopping_criteria``: all of the following must be specified. If any of the criteria are met, then the parameter generation will stop:
         - One of ``min_delta_chi2_abs`` or ``min_delta_chi2_rel`` must be set: float, absolute or relative tolerance for ending the parameter search. If an iteration does not improve the minimum chi2 by this threshold, no new iteration will be performed.
         - ``n_max_mods``: int, maximum number of models desired
-        - ``n_max_iter``: int, maximum number of iterations desired. Note that the iteration IDs are then ``0,... n_max_iter-1``. As iterations 0 and 1 are calculated together (the former consisting of just one model with all parameters fixed at their respective ``value`` attribute), ``n_max_iter=1`` and ``n_max_iter=2`` will both execute both iterations 0 and 1.
+        - ``n_max_iter``: int, maximum number of iterations to be run. The iteration a model was created in is listed under the ``which_iter`` column of the ``all_models`` table, and these are indexed from ``0,... n_max_iter-1``. The ``n_max_iter`` setting controls the total *cumulative* number of iterations to run i.e. if you specify ``n_max_iter=10`` and there are existing models which ``which_iter=9``, then no new iterations will be run. Note that the first two iterations are always run together i.e. whether you specify ``n_max_iter=1`` or ``n_max_iter=2``, iterations 0 and 1 will both be run.
 
 ``io_settings``
 =====================

--- a/docs/getting_started/configuration.rst
+++ b/docs/getting_started/configuration.rst
@@ -301,7 +301,7 @@ Settings relevant for parameter search.
     - ``stopping_criteria``: all of the following must be specified. If any of the criteria are met, then the parameter generation will stop:
         - One of ``min_delta_chi2_abs`` or ``min_delta_chi2_rel`` must be set: float, absolute or relative tolerance for ending the parameter search. If an iteration does not improve the minimum chi2 by this threshold, no new iteration will be performed.
         - ``n_max_mods``: int, maximum number of models desired
-        - ``n_max_iter``: int, maximum number of iterations desired
+        - ``n_max_iter``: int, maximum number of iterations desired. Note that the iteration IDs are then ``0,... n_max_iter-1``. As iterations 0 and 1 are calculated together (the former consisting of just one model with all parameters fixed at their respective ``value`` attribute), ``n_max_iter=1`` and ``n_max_iter=2`` will both execute both iterations 0 and 1.
 
 ``io_settings``
 =====================

--- a/dynamite/parameter_space.py
+++ b/dynamite/parameter_space.py
@@ -546,7 +546,7 @@ class ParameterGenerator(object):
             # never stop when current_models is empty
             self.check_generic_stopping_critera()
             self.check_specific_stopping_critera()
-            if any(self.status.values()):
+            if any(v for v in self.status.values() if type(v) is bool):
                 self.status['stop'] = True
                 self.logger.info(f'Stopping criteria met: {self.status}.')
 

--- a/dynamite/parameter_space.py
+++ b/dynamite/parameter_space.py
@@ -463,6 +463,8 @@ class ParameterGenerator(object):
                 if self._is_newmodel(m, eps=1e-10):
                     self.add_model(m, n_iter=this_iter)
                     newmodels += 1
+        else:
+            self.model_list = []
         self.logger.info(f'{self.name} added {newmodels} new model(s) out of '
                          f'{len(self.model_list)}')
         # combine first two iterations by calling the generator again...
@@ -541,14 +543,12 @@ class ParameterGenerator(object):
         """
         self.status['stop'] = False
         if len(self.current_models.table) > 0:
-        # never stop when current_models is empty
+            # never stop when current_models is empty
             self.check_generic_stopping_critera()
             self.check_specific_stopping_critera()
-            for key in [reasons for reasons in self.status \
-                        if isinstance(reasons, bool) and reasons != 'stop']:
-                if self.status[key]:
-                    self.status['stop'] = True
-                    break
+            if any(self.status.values()):
+                self.status['stop'] = True
+                self.logger.info(f'Stopping criteria met: {self.status}.')
 
     def check_generic_stopping_critera(self):
         """check generic stopping critera


### PR DESCRIPTION
Fixed a bug in ParameterGenerator.check_stopping_critera() (that method would never set self.status['stop'] and DYNAMITE would then execute unneeded code).

Tested with `test_nnls.py` (single iteration and multiple iterations) and all tutorial notebooks.
