### PR TITLE
Bayes LOSVD bugfixes: crash when checking for pops columns in BayesLOSVD data, kinematic maps not created

### DIFF
--- a/docs/more_info/changelog.rst
+++ b/docs/more_info/changelog.rst
@@ -4,6 +4,7 @@
 Change Log
 ****************
 
+- Bugfix: fix a bug that prevents Bayes LOSVD kinemtic maps from being created more than once
 - Improvement: added a new tutorial notebook ``7_orbital_distributions.ipynb`` which takes a closer look at orbit distributions.
 - Improvement: the ``weight`` attribute of kinematics and populations is now officially DEPRECATED as it has always been ignored by DYNAMITE.
 - Improvement: DYNAMITE now checks for nan values in the kinematics and mges when first reading the data

--- a/dynamite/kinematics.py
+++ b/dynamite/kinematics.py
@@ -973,8 +973,9 @@ class BayesLOSVD(Kinematics, data.Integrated):
 
         """
         kin_cols = ['binID_BayesLOSVD', 'bin_flux', 'binID_dynamite',
-                    'v', 'sigma', 'xbin', 'ybin', 'losvd', 'dlosvd']
-        pop_cols = [c for c in self.data.colnames if c not in kin_cols]
+                    'v', 'sigma', 'xbin', 'ybin']
+        pop_cols = [c for c in self.data.colnames if c not in kin_cols
+                    and not any(c.startswith(s) for s in ['losvd', 'dlosvd'])]
         self.data.remove_columns(pop_cols)
         has_pops = len(pop_cols) > 0
         pop_cols = ['binID_dynamite'] + pop_cols

--- a/dynamite/plotter.py
+++ b/dynamite/plotter.py
@@ -1511,7 +1511,8 @@ class Plotter():
             cdict['alpha'].append((si, a, a))
 
         newcmap = mpl.colors.LinearSegmentedColormap(name, cdict)
-        plt.register_cmap(cmap=newcmap)
+        if name not in mpl.colormaps or mpl.colormaps[name] != newcmap:
+            mpl.colormaps.register(cmap=newcmap, force=True)
 
         return newcmap
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cmasher>=1.6.0
 cvxopt>=1.2.6
 h5py>=3.1.0
 lmfit
-matplotlib>=3.3.4
+matplotlib>=3.5.3
 numpy>=1.21
 pafit>=2.0.8
 pathos>=0.2.7


### PR DESCRIPTION
This PR fixes the following problems connected to Bayes LOSVD:

- When using BayesLOSVD, pops columns were incorrectly identified causing a crash when calling `BayesLOSVD.convert_losvd_columns_to_one_multidimensional_column()`. This happened regardless of pops columns existing or not.
- Bayes LOSVD kinematic maps were not created for iterations 2+. The reason is that matplotlib raises an error or warning when re-registering a colormap. Fixed this by avoiding re-registering the same colormap in each iteration.

Tested successfully with tutorial `4_BayesLOSVD.ipynb` and a changed configuration file to allow for more iterations (`n_max_mods: 10`, `n_max_iter: 3`).

Please have a look at the code, test with any BayesLOSVD model and merge if successful ;-)

