### PR TITLE
Reattempt failures bug

### DIFF
--- a/dynamite/weight_solvers.py
+++ b/dynamite/weight_solvers.py
@@ -289,6 +289,10 @@ class LegacyWeightSolver(WeightSolver):
                      os.path.isfile(self.fname_nn_nnls) and
                      os.path.isfile(fname_nn_orbmat))
             if ignore_existing_weights or not check:
+                for f in [self.fname_nn_kinem, self.fname_nn_nnls,
+                          fname_nn_orbmat]:
+                    if os.path.isfile(f):
+                        os.remove(f)
                 # set the current directory to the directory in which
                 # the models are computed
                 cur_dir = os.getcwd()

--- a/dynamite/weight_solvers.py
+++ b/dynamite/weight_solvers.py
@@ -858,7 +858,6 @@ class NNLS(WeightSolver):
                 self.logger.error(text)
                 raise ValueError(text)
             if not np.isnan(weights[0]):
-                np.savetxt(self.weight_file, weights)
                 self.logger.info("NNLS problem solved")
                 # calculate chi2s
                 chi2_vector = (np.dot(A, weights) - b)**2.

--- a/dynamite/weight_solvers.py
+++ b/dynamite/weight_solvers.py
@@ -858,7 +858,6 @@ class NNLS(WeightSolver):
                 self.logger.error(text)
                 raise ValueError(text)
             if not np.isnan(weights[0]):
-                self.logger.info("NNLS problem solved")
                 # calculate chi2s
                 chi2_vector = (np.dot(A, weights) - b)**2.
                 chi2_tot = np.sum(chi2_vector)
@@ -874,6 +873,7 @@ class NNLS(WeightSolver):
                 results.write(self.weight_file,
                               format='ascii.ecsv',
                               overwrite=True)
+                self.logger.info("NNLS problem solved and chi2 calculated.")
             else:
                 chi2_tot = chi2_kin = chi2_kinmap = np.nan
             # delete existing .yaml files and copy current config file


### PR DESCRIPTION
This PR fixes two problems connected to the recovery of an aborted DYNAMITE run:

### Fix 1
When recovering from a run with incomplete weight solving, `LegacyWeightSolver` got confused when there are remaining legacy output files of a previous run in the model directory, leading to DYNAMITE crashing. This PR makes sure that none of the `nn_kinem.out`, `nn_nnls.out`, and `nn_orbmat.out` files exists before reattempting weight solving with the `LegacyWeightSolver`.

Testing suggestion:
Use `test_nnls.py` and change its config file `user_test_config_ml.yaml` so it has the entries:
weight solver `type: LegacyWeightSolver` / `nnls_solver: 1`, `n_max_mods: 10`, `n_max_iter: 10`.

1. Run the script so that models and the all_models table get created.
2. In the script, line 36, change `reset_existing_output=True` to `reset_existing_output=False`
3. In `NGC6278_output/all_models.ecsv`, change both `weights_done` and `all_done` to `False` for the models in `orblib_000_000/ml02.00/` and `orblib_000_000/ml01.50/`. In both of these directories, delete the files `orbit_weights.ecsv`.
4. Re-run `test_nnls.py`. The `LegacyWeightSolver` should run again and re-create the `orbit_weights.ecsv` files.

Explanation: before the changes in this PR, DYNAMITE would crash after step 4, now it successfully re-creates the missing weights and continues running.

### Fix 2
Users were confused by corrupt `orbit_weights.ecsv` files after frozen/crashed DYNAMITE jobs.
What happened:
When using any of the two Python weight solvers, the weights were saved in `orbit_weights.ecsv` in non-ecsv format (also missing the $\chi^2$ values) just before the $\chi^2$ values (sic!) are calculated. Immediately after that, the correct `orbit_weights.ecsv` was written, replacing the previous one. In rare cases when DYNAMITE crashes or freezes between the two write statements, a corrupt and misleading `orbit_weights.ecsv` was left in the model directory.

This PR applies a minor change in `weight_solvers.py`, removing the superfluous and confusing first save statement for the orbit weights in Python NNLS.

Testing: please inspect the changes in `weight_solvers.py`, lines 860-876 (only 3 lines changed).