### PR TITLE
Avoid RuntimeWarning

### DIFF
--- a/dynamite/kinematics.py
+++ b/dynamite/kinematics.py
@@ -879,7 +879,9 @@ class Histogram(object):
         na = np.newaxis
         mean = np.sum(self.x[na,:,na] * self.y * self.dx[na,:,na], axis=1)
         norm = self.get_normalisation()
-        mean /= norm
+        # ignore invalid operations resulting in np.nan (such as 0/0 -> np.nan)
+        with np.errstate(invalid='ignore'):
+            mean /= norm
         return mean
 
     def get_sigma(self):


### PR DESCRIPTION
Avoid `RuntimeWarning: invalid value encountered in divide` in `Histogram.get_mean()`. This warning is confusing to users and results from certain components of mean (before normalization) = 0 and norm = 0 for the same orbit (bundle) and aperture, causing a 0/0 situation (note that this is not a division by zero but undefined as both dividend and divisor are zero). This PR sets numpy's errstate such that 0/0 situations are ignored just for the one division statement in question.

Tested with `test_nnls.py` and Python 3.8 and 3.12.

Will be merged into master right away due to its simplicity...