### PR TITLE
Custom sampling of polar grid

### DIFF
--- a/dev_tests/user_test_config_ml.yaml
+++ b/dev_tests/user_test_config_ml.yaml
@@ -153,6 +153,10 @@ orblib_settings:
     nI2: 5        # must be >= 4
     nI3: 4
     dithering: 1
+    # sampling of grid recording the intrinsic moments, default: 10, 6, 6
+    # quad_nr: 10
+    # quad_nth: 6
+    # quad_nph: 6
     #the following values should usually not be changed
     orbital_periods: 200
     sampling: 50000

--- a/dev_tests/user_test_config_ml.yaml
+++ b/dev_tests/user_test_config_ml.yaml
@@ -154,9 +154,9 @@ orblib_settings:
     nI3: 4
     dithering: 1
     # sampling of grid recording the intrinsic moments, default: 10, 6, 6
-    # quad_nr: 10
-    # quad_nth: 6
-    # quad_nph: 6
+    quad_nr: 10
+    quad_nth: 6
+    quad_nph: 6
     #the following values should usually not be changed
     orbital_periods: 200
     sampling: 50000

--- a/docs/getting_started/configuration.rst
+++ b/docs/getting_started/configuration.rst
@@ -232,6 +232,9 @@ This section is used for settings relevant for the calculation of orbit librarie
     - ``logrmin``: log10 of minimum orbit radius in arcsecs
     - ``logrmax``: log10 of maximum orbit radius in arcsecs
     - ``random_seed``: integer, used for stochastically blurring orbit library by the PSF. Any value :math:`\leq 0` gives a stochastic seed.
+    - ``quad_nr``: integer, sampling of grid recording the intrinsic moments in :math:`r`, default if missing: 10
+    - ``quad_nth``: integer, sampling of grid recording the intrinsic moments in :math:`\theta`, default if missing: 6
+    - ``quad_nph``: integer, sampling of grid recording the intrinsic moments in :math:`\phi`, default if missing:  6
 
 The following settings must also be set in the configuration files but have *typical* values which should generally be sufficient and should not be changed,
 
@@ -247,7 +250,7 @@ There is also an optional setting,
 - ``orblib_settings``
     - ``use_new_mirroring``: boolean
 
-This controls whether or not to use the correction to orbit mirroring introduces in `Quenneville et al 2021 <https://arxiv.org/abs/2111.06904>`_ . This is optional: if ommited, the default is True.
+This controls whether or not to use the correction to orbit mirroring introduces in `Quenneville et al 2021 <https://arxiv.org/abs/2111.06904>`_ . This is optional: if omitted, the default is True.
 
 
 ``weight_solver_settings``

--- a/docs/more_info/changelog.rst
+++ b/docs/more_info/changelog.rst
@@ -4,6 +4,7 @@
 Change Log
 ****************
 
+- Improvement: Sampling of grid recording the intrinsic moments (in r, theta, phi) can optionally be defined in the config file's orblib settings.
 - Improvement: The installation procedure has been changed to make DYNAMITE compatible with Python 3.12. Installing and uninstalling is now done using pip.
 - Improvement: added a new tutorial notebook ``7_orbital_distributions.ipynb`` which takes a closer look at orbit distributions.
 - Improvement: the ``weight`` attribute of kinematics and populations is now officially DEPRECATED as it has always been ignored by DYNAMITE.

--- a/dynamite/config_reader.py
+++ b/dynamite/config_reader.py
@@ -94,6 +94,13 @@ class Settings(object):
                    f"{self.orblib_settings['nI2']}."
             self.logger.error(text)
             raise ValueError(text)
+        for quad in ['nr', 'nth', 'nph']:
+            key = 'quad_' + quad
+            if key not in self.orblib_settings.keys():
+                default = 10 if quad == 'nr' else 6
+                self.orblib_settings[key] = default
+                self.logger.info(f'No value given for orblib setting {key} '
+                                 f'- set to its default {default}.')
         self.logger.debug('Settings validated.')
 
     def __repr__(self):
@@ -483,10 +490,9 @@ class Configuration(object):
             self.logger.error(text)
             raise ValueError(text)
         logger.info('System assembled')
+        self.validate()
         logger.debug(f'System: {self.system}')
         logger.debug(f'Settings: {self.settings}')
-
-        self.validate()
         logger.info('Configuration validated')
 
         if 'generator_settings' in self.settings.parameter_space_settings:

--- a/dynamite/orblib.py
+++ b/dynamite/orblib.py
@@ -198,6 +198,9 @@ class LegacyOrbitLibrary(OrbitLibrary):
         text += f"{settngs['nI2']}\n"
         text += f"{settngs['nI3']}\n"
         text += f"{settngs['dithering']}\n"
+        text += f"{settngs['quad_nr']}\n"
+        text += f"{settngs['quad_nth']}\n"
+        text += f"{settngs['quad_nph']}\n"
         text += f"{dm_specs}\n"
         text += f"{dm_par_vals}"
         if self.system.is_bar_disk_system():

--- a/legacy_fortran/orblib_f.f90
+++ b/legacy_fortran/orblib_f.f90
@@ -2193,16 +2193,13 @@ contains
     !++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
     subroutine qgrid_setup()
         use initial_parameters, only: nEner, nI2, nI3, rLogMin, rLogMax, sigobs_km &
-                                      , conversion_factor
+                                      , conversion_factor &
+                                      , quad_nr, quad_nth, quad_nph
         use integrator, only: integrator_dithering
         !----------------------------------------------------------------------
-        integer(kind=i4b) :: i, quad_nr, quad_nth, quad_nph
+        integer(kind=i4b) :: i
         real(kind=dp)  :: inR, psfsize
         print *, "  ** Octant grid module setup"
-
-        quad_nr = 10   !10 !15 ! int(NEner / integrator_dithering*0.55 )
-        quad_nth = 6    !4  !4 ! int(nI2   / integrator_dithering ) - 1 ! towards middle axis
-        quad_nph = 6    ! 5 !5 ! int(nI3   / integrator_dithering ) - 1 ! towards minor axis
 
         print *, "  ** Grid dimension:"
         print *, quad_nr, quad_nth, quad_nph

--- a/legacy_fortran/orblib_f_new_mirror.f90
+++ b/legacy_fortran/orblib_f_new_mirror.f90
@@ -2362,16 +2362,13 @@ contains
     !++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
     subroutine qgrid_setup()
         use initial_parameters, only: nEner, nI2, nI3, rLogMin, rLogMax, sigobs_km &
-                                      , conversion_factor
+                                      , conversion_factor &
+                                      , quad_nr, quad_nth, quad_nph
         use integrator, only: integrator_dithering
         !----------------------------------------------------------------------
-        integer(kind=i4b) :: i, quad_nr, quad_nth, quad_nph
+        integer(kind=i4b) :: i
         real(kind=dp)  :: inR, psfsize
         print *, "  ** Octant grid module setup"
-
-        quad_nr = 10   !10 !15 ! int(NEner / integrator_dithering*0.55 )
-        quad_nth = 6    !4  !4 ! int(nI2   / integrator_dithering ) - 1 ! towards middle axis
-        quad_nph = 6    ! 5 !5 ! int(nI3   / integrator_dithering ) - 1 ! towards minor axis
 
         print *, "  ** Grid dimension:"
         print *, quad_nr, quad_nth, quad_nph


### PR DESCRIPTION
This PR implements custom sampling of the polar grid according to optional configuration parameters `quad_nr`, `quad_nth`, `quad_nph`.

The parameters `quad_nr`, `quad_nth`, and `quad_nph` can be specified in the `orblib_settings` of the config file. For compatibility, the default values (10,6,6) are used when the parameters don't exist in the config file. See the example entries in `dev_tests/user_test_config_ml.yaml`, lines 156-159:
```    # sampling of grid recording the intrinsic moments, default: 10, 6, 6
    quad_nr: 10
    quad_nth: 6
    quad_nph: 6
```

@adriano-poci: does this work for you?

Test ideas (@prashjet and/or @adriano-poci: would you have time to test this?):
- Don't specify the parameters in the config file's `orblib_settings`. DYNAMITE should then log one INFO message per parameter informing the user that the default value has been chosen. A later DEBUG log entry (config_reader.py:__init__:495) contains the settings object which lists the actually used `quad_nr`, `quad_nth`, and `quad_nph` values.
- Specify parameter values in the config file's `orblib_settings`. A DEBUG log entry (config_reader.py:__init__:495) contains the settings object which lists the actually used `quad_nr`, `quad_nth`, and `quad_nph` values.

So far tested with `test_nnls.py`:
- Verified that apart from the above mentioned log entries, also `models/orblib_000_000/infil/parameters_lum.in` (lines 17-19) and `models/orblib_000_000/datfil/triaxmass.log` (line 67, columns 2-4) contain the right `quad_nr`, `quad_nth`, and `quad_nph` numbers.
- Successfully tested with `use_new_mirroring: True` and `use_new_mirroring: False`.

Not yet tested with bar galaxies (should work, though).

Note that tutorial notebook `4_BayesLOSVD.ipynb` will fail as long as PR #412 is not merged.