### PR TITLE
Fix freezing weight solver

### DIFF
--- a/docs/getting_started/configuration.rst
+++ b/docs/getting_started/configuration.rst
@@ -325,13 +325,19 @@ Settings for multiprocessing. Models can be evaluated in parallel, with the numb
   multiprocessing_settings:
       ncpus: 4                              # integer or string 'all_available' (default: 'all_available')
       ncpus_weights: 4                      # int or 'all_available', optional (default: ncpus), not used by all iterators
-      orblibs_in_parallel: True             # calculate tube and box orbits in parallel (default: True)
+      orblibs_in_parallel: True             # calculate tube and box orbits in parallel (default: False)
       modeliterator: 'SplitModelIterator'   # optional (default: 'ModelInnerIterator')
 
-Due to very different CPU and memory consumption of orbit integration and weight solving, there are two different settings: while orbit integration will use ``ncpus``, weight solving will use ``ncpus_weights`` parallel processes. Note that ``ncpus_weights`` will default to ``ncpus`` if not specified. Currently, only the ``SplitModelIterator`` model iterator and recovering from an unsuccessful weight solving attempt (``reattempt_failures=True``) use the ``ncpus_weights`` setting.
+Due to very different CPU and memory consumption of orbit integration and weight solving, there are two different settings: while orbit integration will use ``ncpus``, weight solving will use ``ncpus_weights`` parallel processes, with ``ncpus`` ≥ ``ncpus_weights`` in general. Note that ``ncpus_weights`` will default to ``ncpus`` if not specified. Currently, only the ``SplitModelIterator`` model iterator and recovering from an unsuccessful weight solving attempt (``reattempt_failures=True``) use the ``ncpus_weights`` setting.
 
-If ``ncpus : 'all_available'`` or ``ncpus_weights : 'all_available'`` is set, then DYNAMITE automatically detects the number of available cpus for parallelisation.
+If ``orblibs_in_parallel`` is set to ``False``, DYNAMITE will first integrate the tube orbits and then the box orbits. If it is set to ``True``, the tube and box orbits will be integrated in parallel, which will use 2 parallel processes per model.
 
+If ``ncpus : 'all_available'`` or ``ncpus_weights : 'all_available'`` is set, then DYNAMITE automatically detects the number of available cpus :math:`N_\mathrm{CPU}` for parallelisation and will set ``ncpus`` = ``ncpus_weights`` = :math:`N_\mathrm{CPU}`.
+
+Important performance hint:
+
+- Most ``numpy`` and ``scipy`` implementations are compiled for shared-memory parallelism (e.g., involving blas/openblas). This can be verified by inspecting the ``MAX_THREADS`` values in the output of ``numpy.__config__.show()`` and ``scipy.__config__.show()``, respectively. The number of threads to be used by ``numpy`` and ``scipy`` can be limited by setting the environment variable ``OMP_NUM_THREADS`` to the desired value before executing DYNAMITE.
+- Recommendation: ``OMP_NUM_THREADS=n`` with ``ncpus * n`` ≤ :math:`N_\mathrm{CPU}` if ``orblibs_in_parallel`` is set to ``False`` and ``ncpus * n`` ≤ :math:`\frac{1}{2}\,N_\mathrm{CPU}` if ``orblibs_in_parallel`` is set to ``True``.
 
 ``legacy_settings``
 =====================

--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -118,7 +118,9 @@ returns its location, something like ``/opt/local/bin/gfortran``.
 Python
 ------
 
-The user is communicating with the Fortran source code via Python. The basic requirement for DYNAMITE is therefore a reasonably current version of Python (Python 3.8 or later).
+The user is communicating with the Fortran source code via Python.
+The basic requirement for DYNAMITE is therefore a reasonably current version of Python
+(Python 3.9 or later as Python 3.8 has reached its end of life as of October 7, 2024).
 
 
 
@@ -553,8 +555,8 @@ The 'G / P' column refers to the weight solver:
    :header-rows: 1
 
    OS and release,  Fortran release,    Python rel.,    G / P,  Date tested,    Remarks
-   macOS 14.4.1,    gfortran 12.2.0,    3.8.19,         G,      2024-04-23
    macOS 14.4.1,    gfortran 12.2.0,    3.9.19,         G,      2024-04-23
+   macOS 14.6.1,    gfortran 12.4.0,    3.11.10,        G,      2024-11-30
    macOS 14.4.1,    gfortran 12.2.0,    3.12.3,         G,      2024-04-23
    AlmaLinux 8.5,   gfortran 8.5.0,     3.10.14,        G,      2024-04-23,     VSC5 w/o modules loaded
    AlmaLinux 8.5,   gfortran 8.5.0,     3.12.3,         G,      2024-04-23,     VSC5 w/o modules loaded, with miniconda

--- a/docs/more_info/changelog.rst
+++ b/docs/more_info/changelog.rst
@@ -4,7 +4,7 @@
 Change Log
 ****************
 
-- Improvement: Updated requirements e.g., to Python 3.9 or later (Python 3.8 has reached its end of life Oct 7, 2024)
+- Improvement: Updated requirements to Python 3.9 or later (Python 3.8 end of life was Oct 7, 2024) and numpy<1.27.0, scipy>=1.11,<1.12 to avoid Python NNLS freeze
 - Improvement: made DYNAMITE compatible with numpy 2.0.0 and matplotlib 3.9.0 (removed use of deprecated features)
 - Bugfix: fix a bug that prevents Bayes LOSVD kinemtic maps from being created more than once
 - Improvement: misc. improvements in documentation and tutorials.

--- a/docs/more_info/changelog.rst
+++ b/docs/more_info/changelog.rst
@@ -4,6 +4,7 @@
 Change Log
 ****************
 
+- Improvement: Updated requirements e.g., to Python 3.9 or later (Python 3.8 has reached its end of life Oct 7, 2024)
 - Improvement: made DYNAMITE compatible with numpy 2.0.0 and matplotlib 3.9.0 (removed use of deprecated features)
 - Bugfix: fix a bug that prevents Bayes LOSVD kinemtic maps from being created more than once
 - Improvement: misc. improvements in documentation and tutorials.

--- a/dynamite/config_reader.py
+++ b/dynamite/config_reader.py
@@ -472,7 +472,7 @@ class Configuration(object):
                     value['modeliterator'] = 'ModelInnerIterator'
                 logger.debug(f"... using iterator {value['modeliterator']}.")
                 if 'orblibs_in_parallel' not in value:
-                    value['orblibs_in_parallel'] = True
+                    value['orblibs_in_parallel'] = False
                 logger.debug("... integrate orblibs in parallel: "
                              f"{value['orblibs_in_parallel']}.")
                 logger.debug(f'multiprocessing_settings: {tuple(value.keys())}')

--- a/dynamite/kinematics.py
+++ b/dynamite/kinematics.py
@@ -539,7 +539,7 @@ class GaussHermite(Kinematics, data.Integrated):
         w_pow_i = np.stack([w**i for i in range(n_herm)])
         # coeffients has shape (n_herm, n_herm)
         # w_pow_i has shape (n_herm, n_regions, n_vbins)
-        result = np.einsum('ij,jkl->ikl', coeffients, w_pow_i, optimize=True)
+        result = np.einsum('ij,jkl->ikl', coeffients, w_pow_i, optimize=False)
         return result
 
     def evaluate_losvd(self, v, v_mu, v_sig, h):
@@ -582,7 +582,7 @@ class GaussHermite(Kinematics, data.Integrated):
                           nrm.pdf(w),
                           h,
                           hpolys,
-                          optimize=True)
+                          optimize=False)
         return losvd
 
     def evaluate_losvd_normalisation(self, h):
@@ -676,7 +676,7 @@ class GaussHermite(Kinematics, data.Integrated):
                       nrm.pdf(w),
                       hpolys,
                       vel_hist.dx,
-                      optimize=True)
+                      optimize=False)
         h *= 2 * np.pi**0.5 # pre-factor in eqn 7
         return h
 
@@ -1442,7 +1442,7 @@ class BayesLOSVD(Kinematics, data.Integrated):
         rebined_orbit_vel_hist = np.einsum('ijk,lj->ilk',
                                            losvd_histograms.y,
                                            f,
-                                           optimize=True)
+                                           optimize=False)
         return rebined_orbit_vel_hist
 
     def transform_orblib_to_observables(self,

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,12 +3,12 @@ cmasher>=1.6.0
 h5py>=3.1.0
 lmfit
 matplotlib>=3.5.3
-numpy>=1.21
+numpy>=1.21.6,<1.27.0
 pafit>=2.0.8
 pathos>=0.2.7
 plotbin>=3.1.7
 PyYAML>=5.4.1
-scipy>=1.10
+scipy>=1.11,<1.12
 six
 sparse>=0.14.0
 vorbin>=3.1.4


### PR DESCRIPTION
Users experienced problems (freezing and/or crashes) in weight solving. Strangely, some issues only occurred in batch jobs and notebooks, but not in directly executed Python scripts (same Python version, same package versions, same environment).

Two problems were identified, individual numpy and scipy versions seem to behave differently depending on 'interactive' or 'batch' use (?). In 'batch' use (i.e., notebooks and probably slurm jobs): (a) `numpy.einsum(..., optimize=True)` freezes without an error message in newer numpy versions and (b) `scipy.optimize.nnls` freezes without an error message in scipy >= 1.12.

This PR fixes this behavior by
- Replacing `optimize=True` by `optimize=False` in `numpy.einsum`, avoiding einsum freezes in newer numpy versions (reason unclear).
- Putting more stringent constraints on the `numpy` and `scipy` releases, based on (a) [this](https://docs.scipy.org/doc/scipy-1.14.1/dev/toolchain.html) information on scipy.org and (b) DYNAMITE tests (execution from command line and notebooks/shell scripts) which further narrowed down working numpy-scipy releases. Educated guess: it may be connected to the reimplementation of `scipy.optimize.nnls` in `scipy 1.12` as mentioned in #401.
- Updating the supported Python versions in the docs, eliminating Python 3.8 as it reached its end of life last October.

With these changes, weight solving should not freeze anymore.

Tested so far:
- `test_nnls.py` works as expected with all three weight solvers (NNLS/scipy, NNLS/cvxopt, LegacyWeightSolver)
- `test_notebooks.sh` executes all tutorial notebooks successfully (did freeze previously)
- The previously freezing `2_quickstart.ipynb` works as expected

@prashjet, if you have time:
While the tests were executed in a fresh Python 3.11 environment, it would be great if you can test on your machine as well (`test_nnls.py` and the tutorial notebooks via `test_notebooks.sh` and interactively).

@afeldmei:
I think this PR might solve your issue with the slurm jobs that freeze forever but (at least partly) execute when started interactively. Please try to check out this PR (or apply its changes manually) and resubmit a job to verify.
