### PR TITLE
Avoid divisions by zero if min_delta_chi2_abs=0 or min_delta_chi2_rel=0.

### DIFF
--- a/dynamite/parameter_space.py
+++ b/dynamite/parameter_space.py
@@ -597,12 +597,15 @@ class ParameterGenerator(object):
             # Don't use abs() so we stop on increasing chi2 values, too:
             delta_chi2 = previous_chi2 - last_chi2
             if self.min_delta_chi2_rel:
-                delta_chi2 /= previous_chi2
-                delta_chi2 /= self.min_delta_chi2_rel
+                if self.min_delta_chi2_rel >= np.spacing(1.):
+                    if delta_chi2 / previous_chi2 < self.min_delta_chi2_rel:
+                        self.status['min_delta_chi2_reached'] = True
+                else:  # Catch cases where min_delta_chi2_rel < eps
+                    if delta_chi2  < 0:
+                        self.status['min_delta_chi2_reached'] = True
             else:
-                delta_chi2 /= self.min_delta_chi2_abs
-            if delta_chi2 <= 1:
-                self.status['min_delta_chi2_reached'] = True
+                if delta_chi2 < self.min_delta_chi2_abs:
+                    self.status['min_delta_chi2_reached'] = True
         # (ii) if step_size < min_step_size for all params
         #       => dealt with by grid_walk (doesn't create such models)
 


### PR DESCRIPTION
This PR should fix Problems with creating new models if `min_delta_chi2_abs=0` or `min_delta_chi2_rel=0`.

@afeldmei, if you have time it would be great if you could test whether `min_delta_chi2_abs=0` and `min_delta_chi2_rel=0` work now :-)