### PR TITLE
Better logging messages and more stable error handling

### DIFF
--- a/docs/more_info/changelog.rst
+++ b/docs/more_info/changelog.rst
@@ -4,7 +4,7 @@
 Change Log
 ****************
 
-
+- Improvement: better error messages to improve debugging with multiprocessing
 - Improvement: minor improvements of tutorials 2 and 3
 
 Version: 4.3

--- a/docs/more_info/changelog.rst
+++ b/docs/more_info/changelog.rst
@@ -4,6 +4,7 @@
 Change Log
 ****************
 
+- Bugfix: avoid DYNAMITE crashing because it gets stuck in a model directory due to a Fortran error
 - Improvement: better error messages to improve debugging with multiprocessing
 - Improvement: minor improvements of tutorials 2 and 3
 

--- a/dynamite/analysis.py
+++ b/dynamite/analysis.py
@@ -516,7 +516,8 @@ class Analysis:
         stars = self.config.system.get_component_from_class(
                                 dyn.physical_system.TriaxialVisibleComponent)
         kin_name = stars.kinematic_data[kin_set].name
-        self.logger.info('Getting model projected masses and losvds.')
+        self.logger.info('Getting projected masses and losvds for '
+                         f'model {model.directory}.')
         orblib = model.get_orblib()
         if weights is None:
             _ = model.get_weights(orblib)

--- a/dynamite/model.py
+++ b/dynamite/model.py
@@ -452,7 +452,8 @@ class AllModels(object):
             if np.allclose(row_comp, tuple(row)):
                 break
         else:
-            text = 'Cannot find model in all_models table.'
+            text = 'Cannot find model with parset ' \
+                   f'{row_comp} in all_models table.'
             self.logger.error(text)
             raise ValueError(text)
         return row_id
@@ -489,16 +490,18 @@ class AllModels(object):
                               "implementation")
             raise
         row_comp = tuple(self.table[orblib_parameters][model_id])
+        model_dir = self.table['directory'][model_id]
         for row_id, row in enumerate( \
                                  self.table[orblib_parameters][:model_id+1]):
             if np.allclose(row_comp, tuple(row)):
                 ml_orblib = self.table['ml'][row_id]
-                self.logger.debug(f'Orblib of model #{model_id} has original '
+                ml_orblib_dir = self.table['directory'][row_id]
+                self.logger.debug(f'Orblib of model {model_dir} has original '
                                   f'ml value of {ml_orblib} '
-                                  f'(model #{row_id}).')
+                                  f'(model {ml_orblib_dir}).')
                 break
         else:
-            text = f'Cannot find orblib for model #{model_id} in ' \
+            text = f'Cannot find orblib of model {model_dir} in ' \
                    'all_models table.'
             self.logger.error(text)
             raise ValueError(text)

--- a/dynamite/model.py
+++ b/dynamite/model.py
@@ -889,7 +889,7 @@ class Model(object):
         """
         if not os.path.isfile(self.config.config_file_name):
             txt = f'Unexpected: config file {self.config.config_file_name}' + \
-                  ' not found.'
+                  f' not found (looking in {os.getcwd()}).'
             self.logger.error(txt)
             raise FileNotFoundError(txt)
         model_yaml_files = glob.glob(self.directory+'*.yaml')

--- a/dynamite/orblib.py
+++ b/dynamite/orblib.py
@@ -728,11 +728,15 @@ class LegacyOrbitLibrary(OrbitLibrary):
         hist_centers += [p.hist_center for p in pops]
         hist_bins = [k.hist_bins for k in stars.kinematic_data]
         hist_bins += [p.hist_bins for p in pops]
-        self.logger.debug('Checking number of velocity bins...')
-        error_msg = 'must have odd number of velocity bins for all ' \
-                    'kinematics and populations'
-        assert np.all(np.array(hist_bins) % 1==0), error_msg
-        self.logger.debug('...checks ok.')
+        self.logger.debug(f'{self.mod_dir}{tmpfname}: '
+                          'checking number of velocity bins...')
+        if np.all(np.array(hist_bins) % 2 == 0):
+            error_msg = f'{self.mod_dir}{tmpfname}: must have odd number of ' \
+                        'velocity bins for all kinematics and populations.'
+            self.logger.error(error_msg)
+            os.chdir(cur_dir)
+            raise ValueError(error_msg)
+        self.logger.debug(f'...{self.mod_dir}{tmpfname}: checks ok.')
         n_apertures = [k.n_spatial_bins for k in stars.kinematic_data]
         n_apertures += [p.n_spatial_bins for p in pops]
         # get index linking  kinematic set to aperture

--- a/dynamite/orblib.py
+++ b/dynamite/orblib.py
@@ -425,12 +425,13 @@ class LegacyOrbitLibrary(OrbitLibrary):
         cur_dir = os.getcwd()
         os.chdir(self.mod_dir)
         cmdstr = self.write_executable_for_ics()
-        self.logger.info('Calculating initial conditions')
+        self.logger.info(f'Calculating initial conditions for {self.mod_dir}.')
         # p = subprocess.call('bash '+cmdstr, shell=True)
         p = subprocess.run('bash '+cmdstr,
                            stdout=subprocess.PIPE,
                            stderr=subprocess.STDOUT,
                            shell=True)
+        os.chdir(cur_dir)
         log_file = f'Logfile: {self.mod_dir}datfil/orbstart.log.'
         if not p.stdout.decode("UTF-8"):
             self.logger.info(f'...done - {cmdstr} exit code {p.returncode}. '
@@ -446,7 +447,6 @@ class LegacyOrbitLibrary(OrbitLibrary):
                 text += f'{log_file} Be wary: DYNAMITE may crash...'
                 self.logger.warning(text)
                 raise RuntimeError(text)
-        os.chdir(cur_dir)
 
     def write_executable_for_ics(self):
         """Write the bash script to calculate orbit ICs
@@ -471,12 +471,15 @@ class LegacyOrbitLibrary(OrbitLibrary):
         cur_dir = os.getcwd()
         os.chdir(self.mod_dir)
         cmdstr = self.write_executable_for_integrate_orbits_par()
-        self.logger.info('Integrating orbit library tube and box orbits')
+        self.logger.info('Integrating orbit library tube and box orbits '
+                         f'for {self.mod_dir}.')
         # p = subprocess.call('bash '+cmdstr_tube, shell=True)
         p = subprocess.run('bash '+cmdstr,
                            stdout=subprocess.PIPE,
                            stderr=subprocess.STDOUT,
                            shell=True)
+        # move back to original directory
+        os.chdir(cur_dir)
         log_files = f'Logfiles: {self.mod_dir}datfil/orblib.log, ' \
                     f'{self.mod_dir}datfil/orblibbox.log, ' \
                     f'{self.mod_dir}datfil/triaxmass.log, ' \
@@ -495,8 +498,6 @@ class LegacyOrbitLibrary(OrbitLibrary):
                 text += f'{log_files} Be wary: DYNAMITE may crash...'
                 self.logger.warning(text)
                 raise RuntimeError(text)
-        # move back to original directory
-        os.chdir(cur_dir)
 
     def get_orbit_library(self):
         """Execute the bash script to calculate orbit libraries
@@ -505,12 +506,15 @@ class LegacyOrbitLibrary(OrbitLibrary):
         cur_dir = os.getcwd()
         os.chdir(self.mod_dir)
         cmdstr_tube, cmdstr_box = self.write_executable_for_integrate_orbits()
-        self.logger.info('Integrating orbit library tube orbits')
+        self.logger.info('Integrating orbit library tube orbits '
+                         f'for {self.mod_dir}.')
         # p = subprocess.call('bash '+cmdstr_tube, shell=True)
         p = subprocess.run('bash '+cmdstr_tube,
                            stdout=subprocess.PIPE,
                            stderr=subprocess.STDOUT,
                            shell=True)
+        # move back to original directory
+        os.chdir(cur_dir)
         log_files = f'Logfiles: {self.mod_dir}datfil/orblib.log, ' \
                     f'{self.mod_dir}datfil/triaxmass.log, ' \
                     f'{self.mod_dir}datfil/triaxmassbin.log.'
@@ -528,12 +532,16 @@ class LegacyOrbitLibrary(OrbitLibrary):
                 text += f'{log_files} Be wary: DYNAMITE may crash...'
                 self.logger.warning(text)
                 raise RuntimeError(text)
-        self.logger.info('Integrating orbit library box orbits')
+        os.chdir(self.mod_dir)
+        self.logger.info('Integrating orbit library box orbits '
+                         f'for {self.mod_dir}.')
         # p = subprocess.call('bash '+cmdstr_box, shell=True)
         p = subprocess.run('bash '+cmdstr_box,
                            stdout=subprocess.PIPE,
                            stderr=subprocess.STDOUT,
                            shell=True)
+        # move back to original directory
+        os.chdir(cur_dir)
         log_file = f'Logfile: {self.mod_dir}datfil/orblibbox.log.'
         if not p.stdout.decode("UTF-8"):
             self.logger.info(f'...done - {cmdstr_box} exit code '
@@ -549,8 +557,6 @@ class LegacyOrbitLibrary(OrbitLibrary):
                 text += f'{log_file} Be wary: DYNAMITE may crash...'
                 self.logger.warning(text)
                 raise RuntimeError(text)
-        # move back to original directory
-        os.chdir(cur_dir)
 
     def write_executable_for_integrate_orbits_par(self):
         """Write the bash script to calculate orbit libraries

--- a/dynamite/orblib.py
+++ b/dynamite/orblib.py
@@ -932,7 +932,14 @@ class LegacyOrbitLibrary(OrbitLibrary):
 
         # TODO: check if this ordering is compatible with weights read in by
         # LegacyWeightSolver.read_weights
-        tube_orblib, tube_density_3D = self.read_orbit_base('orblib')
+        try:
+            tube_orblib, tube_density_3D = self.read_orbit_base('orblib')
+        except:
+            self.logger.error('Something went seriously wrong when reading '
+                              'the tube orbit library. Check disk quota, file '
+                              'integrity, and consistent config files. '
+                              f'Model: {self.mod_dir}.')
+            raise
         if not (kins or pops):
             txt = 'Specify kins or pops.'
             self.logger.error(txt)
@@ -960,7 +967,14 @@ class LegacyOrbitLibrary(OrbitLibrary):
             tube_density_3D = np.repeat(tube_density_3D, 2, axis=0)
 
         # read box orbits
-        box_orblib, box_density_3D = self.read_orbit_base('orblibbox')
+        try:
+            box_orblib, box_density_3D = self.read_orbit_base('orblibbox')
+        except:
+            self.logger.error('Something went seriously wrong when reading '
+                              'the box orbit library. Check disk quota, file '
+                              'integrity, and consistent config files. '
+                              f'Model: {self.mod_dir}.')
+            raise
         if kins and not pops:
             box_orblib = box_orblib[:n_kins]
         else:  # pops is True

--- a/dynamite/weight_solvers.py
+++ b/dynamite/weight_solvers.py
@@ -276,7 +276,8 @@ class LegacyWeightSolver(WeightSolver):
         """
         self.logger.info(f"Using WeightSolver: {__class__.__name__}")
         if (not ignore_existing_weights) and self.weight_file_exists():
-            self.logger.info("Reading NNLS solution from existing output.")
+            self.logger.info("Reading NNLS solution from existing output "
+                             f"{self.weight_file}.")
             results = ascii.read(self.weight_file)
             weights = results['weights']
             chi2_tot = results.meta['chi2_tot']
@@ -824,7 +825,8 @@ class NNLS(WeightSolver):
                                         # orblib.projected_masses
         if (not ignore_existing_weights) and self.weight_file_exists():
             results = ascii.read(self.weight_file, format='ecsv')
-            self.logger.info("NNLS solution read from existing output")
+            self.logger.info("NNLS solution read from existing output "
+                             f"{self.weight_file}.")
             weights = results['weights']
             chi2_tot = results.meta['chi2_tot']
             chi2_kin = results.meta['chi2_kin']
@@ -873,7 +875,8 @@ class NNLS(WeightSolver):
                 results.write(self.weight_file,
                               format='ascii.ecsv',
                               overwrite=True)
-                self.logger.info("NNLS problem solved and chi2 calculated.")
+                self.logger.info("NNLS problem solved and chi2 calculated for "
+                                 f"model {self.direc_with_ml}.")
             else:
                 chi2_tot = chi2_kin = chi2_kinmap = np.nan
             # delete existing .yaml files and copy current config file


### PR DESCRIPTION
In the recent past, several user problems were difficult to diagnose. One reason was that log entries were difficult to connect to the models/model directories where the errors occurred because in multiprocessing, the models' messages are interlaced in the log.

This PR adds model and directory information to those log entries, saving time and effort when debugging.

Bugfix: in some instances DYNAMITE got stuck in individual model directories after noncritical errors, which led to a crash down the road. This should be fixed in this PR.

Tested successfully with `test_nnls.py` and `test_notebooks.sh`.