### PR TITLE
Bugfixes (directory naming, etc.)

### DIFF
--- a/dev_tests/user_test_config_ml.yaml
+++ b/dev_tests/user_test_config_ml.yaml
@@ -204,7 +204,7 @@ io_settings: # paths can be given with or without trailing slash
 multiprocessing_settings:
     ncpus: 'all_available' # integer or 'all_available' for multiprocessing
     ncpus_weights: 'all_available' # integer or 'all_available', optional, defaults to ncpus (not used by all iterators)
-    modeliterator: 'SplitModelIterator' # optional, default 'ModelInnerIterator'
+    # modeliterator: 'SplitModelIterator' # optional, default 'ModelInnerIterator'
     orblibs_in_parallel: False
 
 # end

--- a/dev_tests/user_test_config_ml.yaml
+++ b/dev_tests/user_test_config_ml.yaml
@@ -190,7 +190,7 @@ parameter_space_settings:
     stopping_criteria:
         min_delta_chi2_abs : 0.5  # absolute "optimality tolerance"
         #min_delta_chi2_rel : 0.05 # relative "optimality tolerance"
-        n_max_mods : 3
+        n_max_mods : 4
         n_max_iter : 10
 
 legacy_settings:
@@ -205,6 +205,6 @@ multiprocessing_settings:
     ncpus: 'all_available' # integer or 'all_available' for multiprocessing
     ncpus_weights: 'all_available' # integer or 'all_available', optional, defaults to ncpus (not used by all iterators)
     modeliterator: 'SplitModelIterator' # optional, default 'ModelInnerIterator'
-    orblibs_in_parallel: True
+    orblibs_in_parallel: False
 
 # end

--- a/docs/getting_started/configuration.rst
+++ b/docs/getting_started/configuration.rst
@@ -245,14 +245,6 @@ The following settings must also be set in the configuration files but have *typ
     - ``number_orbits``: integer, the number of orbits to integrate, if -1 then integrate all orbits
     - ``accuracy``: typical ``1.0d-5``, the accuracy of the orbit integrator
 
-There is also an optional setting,
-
-- ``orblib_settings``
-    - ``use_new_mirroring``: boolean
-
-This controls whether or not to use the correction to orbit mirroring introduces in `Quenneville et al 2021 <https://arxiv.org/abs/2111.06904>`_ . This is optional: if omitted, the default is True.
-
-
 ``weight_solver_settings``
 ==========================
 

--- a/docs/more_info/changelog.rst
+++ b/docs/more_info/changelog.rst
@@ -4,6 +4,9 @@
 Change Log
 ****************
 
+- Improvement: more robust directory naming when failed models are present in the all_models table
+- Bugfix: don't crash with pops data when using ModelInnerIterator.
+- Bugfix: don't crash when continuing a run with just one valid model.
 - Improvement: added counter-rotating components to decomposition.
 - Bugfix: fix a bug that prevents Bayes LOSVD kinemtic maps from being created more than once
 - New feature: a dark halo is no longer mandatory (models can consist of either zero or one dark halo component)

--- a/dynamite/model.py
+++ b/dynamite/model.py
@@ -921,7 +921,8 @@ class Model(object):
         c_diff = difflib.unified_diff(config_file,
                                       model_config_file,
                                       fromfile=self.config.config_file_name,
-                                      tofile=model_config_file_name)
+                                      tofile=model_config_file_name,
+                                      n=0)
         c_diff = list(c_diff)
         if len(c_diff) > 0:
             self.logger.warning('ACTION REQUIRED, PLEASE CHECK: '

--- a/dynamite/model_iterator.py
+++ b/dynamite/model_iterator.py
@@ -282,9 +282,12 @@ class ModelInnerIterator(object):
                         if len(input_list_ml) > 0:
                             output_ml = p.map(self.create_and_run_model,
                                               input_list_ml)
-                self.write_output_to_all_models_table(rows_to_do_orblib,
-                                                      output_orblib)
-                self.write_output_to_all_models_table(rows_to_do_ml, output_ml)
+                    if len(input_list_orblib) > 0:
+                        self.write_output_to_all_models_table(rows_to_do_orblib,
+                                                              output_orblib)
+                    if len(input_list_ml) > 0:
+                        self.write_output_to_all_models_table(rows_to_do_ml,
+                                                              output_ml)
             self.all_models.save()  # save all_models table once models are run
             self.logger.info('Iteration done, '
                              f'{self.n_to_do} model(s) calculated.')

--- a/dynamite/orblib.py
+++ b/dynamite/orblib.py
@@ -107,9 +107,8 @@ class LegacyOrbitLibrary(OrbitLibrary):
                 stars = self.system.get_unique_triaxial_visible_component()
             # create the kinematics and populations input files for each
             # kinematic dataset and population dataset with own apertures
-            kin_pops = stars.kinematic_data
-            kin_pops += [p for p in stars.population_data if p.kin_aper is None]
-            for data_set in kin_pops:
+            pops = [p for p in stars.population_data if p.kin_aper is None]
+            for data_set in stars.kinematic_data + pops:
                 # copy aperture and bins files across
                 shutil.copyfile(self.in_dir + data_set.aperturefile,
                                 self.mod_dir + f'infil/{data_set.aperturefile}')

--- a/dynamite/parameter_space.py
+++ b/dynamite/parameter_space.py
@@ -591,6 +591,8 @@ class ParameterGenerator(object):
                 return
             mask = self.current_models.table['which_iter'] <= last_iter
             models1 = self.current_models.table[mask]
+            if len(models1) == 0:
+                return
             previous_chi2 = np.nanmin(models1[self.chi2])
             if np.isnan(previous_chi2):
                 return


### PR DESCRIPTION
This PR addresses multiple issues, originating from difficulties to continue runs where multiple models failed, which caused DYNAMITE to get confused in directory naming. Here's a list what has (hopefully) been fixed (please don't be confused by the branch name):
- The model iterator now identifies newly generated models more robustly (via empty directories rather than `all_done==False`, avoiding confusion with repeatedly failed models still in the all_models table and causing renaming of existing models).
- Bugfix: DYNAMITE no longer crashes with pops data when using `ModelInnerIterator`.
- Bugfix: DYNAMITE no longer crashes when continuing a run with just one valid model.
- Decluttering the log: if the current config file differs from the one used to create an existing model, only display the differing lines, no context.
- Code improvement: Refactored the SplitModelIterator to avoid duplicate code defining of the models that need to be run.

Tested successfully with `test_nnls.py` and `test_notebooks.sh`