### PR TITLE
Ocut in orbit plot

### DIFF
--- a/docs/more_info/changelog.rst
+++ b/docs/more_info/changelog.rst
@@ -4,6 +4,7 @@
 Change Log
 ****************
 
+- Improvement: the orbit_plot now allows custom orbit cuts via the ocut parameter (same behavior as in the Decomposition class)
 - Improvement: added counter-rotating components to decomposition.
 - Bugfix: fix a bug that prevents Bayes LOSVD kinemtic maps from being created more than once
 - New feature: a dark halo is no longer mandatory (models can consist of either zero or one dark halo component)

--- a/dynamite/analysis.py
+++ b/dynamite/analysis.py
@@ -37,7 +37,7 @@ class Decomposition:
         The value of this parameter is the index of the data
         set (e.g. kin_set=0, kin_set=1). The default is 0.
     ocut : list of floats, optional
-        The cuts in lambda_z. The default is None, which translates to
+        The orbit cuts in lambda_z. The default is None, which translates to
         ocut=[0.8, 0.25, -0.25, -0.8], the selection in lambda_z
         following Santucci+22.
     decomp_table : bool, optional
@@ -493,11 +493,11 @@ class Decomposition:
         # map components
         comp_map = np.zeros(n_orbs, dtype=int)
         # cold component (thin disk)
-        comp_map[np.ravel(np.where(lzm_sign >= ocut[0]))] += \
+        comp_map[np.ravel(np.where(lzm_sign > ocut[0]))] += \
             2**comps.index('thin_d')
         # warm component (thick disk)
         comp_map[np.ravel(np.where((lzm_sign > ocut[1])
-                                 & (lzm_sign < ocut[0])))] += \
+                                 & (lzm_sign <= ocut[0])))] += \
             2**comps.index('thick_d')
         # hot component (bulge)
         comp_map[np.ravel(np.where((lzm_sign > ocut[2])

--- a/dynamite/plotter.py
+++ b/dynamite/plotter.py
@@ -1299,7 +1299,11 @@ class Plotter():
 ######## Routines from schw_orbit.py, necessary for orbit_plot ##############
 #############################################################################
 
-    def orbit_plot(self, model=None, Rmax_arcs=None, figtype=None):
+    def orbit_plot(self,
+                   model=None,
+                   Rmax_arcs=None,
+                   ocut=(0.8, 0.25, -0.25, -0.8),
+                   figtype=None):
         """
         Generates an orbit plot for the selected model
 
@@ -1317,8 +1321,19 @@ class Plotter():
             file's parameter settings is used to determine which chisquare
             to consider. The default is None.
         Rmax_arcs : numerical value
-             upper radial limit for orbit selection, in arcsec i.e only orbits
-             extending up to Rmax_arcs are plotted
+            upper radial limit for orbit selection, in arcsec i.e only orbits
+            extending up to Rmax_arcs are plotted
+        ocut : iterable of numerical values, optional
+            The orbit cuts in lambda_z. The plot will include horizontal
+            dashed lines at the lambda_z levels in ocut.
+            Per default, ocut will have four levels (0.8, 0.25, -0.25, -0.8),
+            interpreted as (lim_cold, lim_warm, lim_hot, lim_cr_warm),
+            decomposing the plot into five regions:
+            cold (lambda_z > lim_cold>),
+            warm (lim_cold >= lambda_z > lim_warm),
+            hot (lim_warm >= lambda_z > lim_hot),
+            counter-rotating warm (lim_hot >= lambda_z > lim_cr_warm),
+            and counter-rotating cold (lim_cr_warm >= lambda_z) orbits.
         figtype : STR, optional
             Determines the file extension to use when saving the figure.
             If None, the default setting is used ('.png').
@@ -1339,9 +1354,11 @@ class Plotter():
             figtype = '.png'
 
         if Rmax_arcs is None:
-            text = f'Rmax_arcs must be a number, but it is {Rmax_arcs}'
+            text = 'Rmax_arcs is a mandatory argument and must be a number.'
             self.logger.error(text)
             raise ValueError(text)
+
+        self.logger.debug(f'Orbit plot parameters: {ocut=}, {Rmax_arcs=}')
 
         if model is None:
             which_chi2 = \
@@ -1449,14 +1466,16 @@ class Plotter():
         ax.set_xlabel(r'$r$ [arcsec]', fontsize=9)
         ax.set_ylabel(r'Circularity $\lambda_{z}$', fontsize=9)
 
-        fig.colorbar(cax, orientation='vertical', pad=0.1)
+        cb = fig.colorbar(cax, orientation='vertical', pad=0.05)
+        cb.set_label('Relative orbit density', labelpad=10)
 
-        ax.plot(imgxrange, np.array([1,1])*0.80, '--', color='black',
-                 linewidth=1)
-        ax.plot(imgxrange, np.array([1,1])*0.25, '--', color='black',
-                 linewidth=1)
-        ax.plot(imgxrange, np.array([1,1])*(-0.25), '--', color='black',
-                 linewidth=1)
+        for cut in ocut:
+            ax.plot(imgxrange,
+                    np.array([1,1])*cut,
+                    '--',
+                    color='black',
+                    linewidth=1)
+
         plt.tight_layout()
         plt.savefig(filename5)
 


### PR DESCRIPTION
Improvements to orbit plotting and Decomposition:
- There is a new parameter to `orbit_plot(..., ocut=(0.8, 0.25, -0.25, -0.8),...)`. `ocut` works the same as in the `Decomposition` class and allows to manually set the orbit cuts in $\lambda_z$. The plot will include horizontal dashed lines at each $\lambda_z$ value. While the user can pass any number of cuts, the default has four levels (0.8, 0.25, -0.25, -0.8), interpreted as (lim_cold, lim_warm, lim_hot, lim_cr_warm), decomposing the plot into five regions.
- Added a label explaining the colorbar in `orbit_plot(...)`.
- Minor improvement to `Decomposition`: made the use of `>` and `>=` consistent. Now the regions are consistently defined by `upper_limit >= lambda_z > lower_limit`.

@liquidreams, if you get a chance please test to verify the orbit plot does what you want ;-) Many thanks!