### PR TITLE
Always generate models on restart

### DIFF
--- a/dev_tests/user_test_config_fixedvalues.yaml
+++ b/dev_tests/user_test_config_fixedvalues.yaml
@@ -31,10 +31,6 @@ system_components:
                 logarithmic: True
                 LaTeX: "$\\log(M_\\mathrm{BH}/M_\\odot)$"
             a: # scale length
-                par_generator_settings:
-                    fixed_values:
-                        - 0.001
-                        - 0.002
                 fixed: True
                 value: 1.e-3  # dot required, renders as str '1e-3' otherwise
                 LaTeX: "$a_\\mathrm{BH}$"
@@ -60,6 +56,10 @@ system_components:
                     hi: 2.0
                     step: 0.5
                     minstep: 0.1
+                    fixed_values:
+                        - 0.5
+                        - 1.0
+                        - 1.5
                 logarithmic: True
                 fixed: True
                 value: 1.0

--- a/docs/more_info/changelog.rst
+++ b/docs/more_info/changelog.rst
@@ -4,6 +4,7 @@
 Change Log
 ****************
 
+- Bugfix: the SpecificModels parameter generator no longer crashes when the varied parameters' indices don't start with 0 and have no gaps.
 - Improvement: Upon restart, always generate models for first iteration, even if stopping criteria are fulfilled.
 - Improvement: more robust directory naming when failed models are present in the all_models table
 - Bugfix: don't crash with pops data when using ModelInnerIterator.

--- a/docs/more_info/changelog.rst
+++ b/docs/more_info/changelog.rst
@@ -4,6 +4,7 @@
 Change Log
 ****************
 
+- Improvement: Upon restart, always generate models for first iteration, even if stopping criteria are fulfilled.
 - Improvement: more robust directory naming when failed models are present in the all_models table
 - Bugfix: don't crash with pops data when using ModelInnerIterator.
 - Bugfix: don't crash when continuing a run with just one valid model.

--- a/dynamite/parameter_space.py
+++ b/dynamite/parameter_space.py
@@ -1366,14 +1366,14 @@ class SpecificModels(ParameterGenerator):
         if self.mode == 'list':
             for i in range(n_mod):
                 new_parset = [copy.deepcopy(p) for p in self.par_space]
-                for idx in par_list_idx:
-                    new_parset[idx].raw_value = fixed_values[idx][i]
+                for val_idx, idx in enumerate(par_list_idx):
+                    new_parset[idx].raw_value = fixed_values[val_idx][i]
                 self.model_list.append([copy.deepcopy(p) for p in new_parset])
         else:
             for val in itertools.product(*fixed_values):
                 new_parset = [copy.deepcopy(p) for p in self.par_space]
-                for idx in par_list_idx:
-                    new_parset[idx].raw_value = val[idx]
+                for val_idx, idx in enumerate(par_list_idx):
+                    new_parset[idx].raw_value = val[val_idx]
                 self.model_list.append([copy.deepcopy(p) for p in new_parset])
 
         return


### PR DESCRIPTION
Per user request by @liquidreams:

After DYNAMITE converged it may be desirable to add more models to verify the optimal parameter set. This PR makes sure, that upon restart, DYNAMITE will always create models for the first iteration, independent of the stopping criteria.

Also, the following bugfix is included in this PR:
The `SpecificModels` parameter generator no longer crashes when the varied parameters' indices don't start with 0 and have no gaps.

Tested with Iris' test galaxy run.

@liquidreams, please test if this works for you.
Feel fee to try the `SpecificModels` parameter generator to investigate models around the optimum. An example config file is `dev_tests/user_test_config_fixedvalues.yaml`