### PR TITLE
Remove possibly broken and unused Histogram.normalise()

### DIFF
--- a/docs/tutorial_notebooks/6_orbits_and_weights.ipynb
+++ b/docs/tutorial_notebooks/6_orbits_and_weights.ipynb
@@ -304,9 +304,8 @@
     "losvd = orblib0.losvd_histograms[0].y[:, :, :]\n",
     "\n",
     "## velocity histograms where vel_hist.y has shape (n_orbits, n_vbins, n_regions)\n",
-    "velhist = dyn.kinematics.Histogram(\n",
-    "    xedg=orblib0.losvd_histograms[0].xedg,\n",
-    "    y=losvd)\n",
+    "velhist = dyn.kinematics.Histogram(xedg=orblib0.losvd_histograms[0].xedg,\n",
+    "                                   y=losvd)\n",
     "\n",
     "v     = kinematics.data[:]['v']\n",
     "sigma = kinematics.data[:]['sigma']\n",
@@ -325,7 +324,7 @@
     "print(f'GH coefficients for orbit {orb_idx} and aperture {aperture_idx}:')\n",
     "i = 1\n",
     "for hi in tmp[orb_idx,aperture_idx,:]:\n",
-    "    print(f'   h_{i} = {hi:.4f}')\n",
+    "    print(f'   h_{i} = {hi:.5f}')\n",
     "    i+=1"
    ]
   },
@@ -500,10 +499,8 @@
     "tmp = orblib0.losvd_histograms[0].y[:,:,]\n",
     "\n",
     "# store them in a histogram object\n",
-    "vel_hist = dyn.kinematics.Histogram(\n",
-    "    xedg=orblib0.losvd_histograms[0].xedg,\n",
-    "    y=tmp,\n",
-    "    normalise=False)\n",
+    "vel_hist = dyn.kinematics.Histogram(xedg=orblib0.losvd_histograms[0].xedg,\n",
+    "                                    y=tmp)\n",
     "\n",
     "\n",
     "# get the GH expansion coefficients for all of these orbits\n",
@@ -571,7 +568,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.11.10"
   }
  },
  "nbformat": 4,

--- a/dynamite/analysis.py
+++ b/dynamite/analysis.py
@@ -394,8 +394,7 @@ class Decomposition:
             self.logger.debug(f'{comp}: {np.count_nonzero(orb_sel)} orbits, '
                               f'{flux.shape=}, {losvd.shape=}.')
             losvd_hist = dyn.kinematics.Histogram(self.losvd_histograms.xedg,
-                                                  y=losvd,
-                                                  normalise=False)
+                                                  y=losvd)
             if v_sigma_option == 'moments':
                 v_mean = np.squeeze(losvd_hist.get_mean())
                 v_sigma = np.squeeze(losvd_hist.get_sigma())
@@ -657,8 +656,7 @@ class Analysis:
         # calculate v_mean and v_sigma values from the losvd histograms
         model_losvd_hist = \
             dyn.kinematics.Histogram(xedg=orblib.losvd_histograms[kin_set].xedg,
-                                     y=model_losvd,
-                                     normalise=False)
+                                     y=model_losvd)
         if v_sigma_option == 'moments':
             v_mean = np.squeeze(model_losvd_hist.get_mean()) # from distr.
             v_sigma = np.squeeze(model_losvd_hist.get_sigma()) # from distr.

--- a/dynamite/kinematics.py
+++ b/dynamite/kinematics.py
@@ -793,8 +793,6 @@ class Histogram(object):
         histogram bin edges
     y : (n_orbits, n_bins+1, n_apertures)
         histogram values
-    normalise : bool, default=True
-        whether to normalise to pdf
 
     Attributes
     ----------
@@ -802,18 +800,14 @@ class Histogram(object):
         bin centers
     dx : array (n_bins,)
         bin widths
-    normalised : bool
-        whether or not has been normalised to pdf
 
     """
-    def __init__(self, xedg=None, y=None, normalise=False):
+    def __init__(self, xedg=None, y=None):
         self.logger = logging.getLogger(f'{__name__}.{__class__.__name__}')
         self.xedg = xedg
         self.x = (xedg[:-1] + xedg[1:])/2.
         self.dx = xedg[1:] - xedg[:-1]
         self.y = y
-        if normalise:
-            self.normalise()
 
     def get_normalisation(self):
         """Get the normalsition
@@ -829,24 +823,6 @@ class Histogram(object):
         na = np.newaxis
         norm = np.sum(self.y*self.dx[na,:,na], axis=1)
         return norm
-
-    def normalise(self):
-        """normalises the LOSVDs
-
-        Returns
-        -------
-        None
-            resets ``self.y`` to a normalised version
-
-        """
-        norm = self.get_normalisation()
-        na = np.newaxis
-        tmp = self.y/norm[:,na,:]
-        # where norm=0, tmp=nan. Fix this:
-        idx = np.where(norm==0.)
-        tmp[idx[0],:,idx[1]] = 0.
-        # replace self.y with normalised y
-        self.y = tmp
 
     def scale_x_values(self, scale_factor):
         """scale the velocity array

--- a/dynamite/orblib.py
+++ b/dynamite/orblib.py
@@ -936,9 +936,7 @@ class LegacyOrbitLibrary(OrbitLibrary):
                     v = (vedg[1:] + vedg[:-1])/2.
                     v_cent = v[idx_center]
                     vedg -= v_cent
-                    vvv = dyn_kin.Histogram(xedg=vedg,
-                                            y=velhist,
-                                            normalise=False)
+                    vvv = dyn_kin.Histogram(xedg=vedg, y=velhist)
                     velhists += [vvv]
         else:
             velhists = []
@@ -967,9 +965,7 @@ class LegacyOrbitLibrary(OrbitLibrary):
             os.chdir(cur_dir)
             # append the populations data to the velhists
             for mass in mass0:
-                vvv = dyn_kin.Histogram(xedg=np.array([-0.5, 0.5]),
-                                        y=mass,
-                                        normalise=False)
+                vvv = dyn_kin.Histogram(xedg=np.array([-0.5, 0.5]), y=mass)
                 velhists += [vvv]
         return velhists, density_3D  #######################
 
@@ -1002,9 +998,7 @@ class LegacyOrbitLibrary(OrbitLibrary):
         new_losvd = np.zeros((2*n_orbs, n_vel_bins, n_spatial_bins))
         new_losvd[0::2] = losvd
         new_losvd[1::2, :] = reveresed_losvd
-        new_orblib = dyn_kin.Histogram(xedg=orblib.xedg,
-                                       y=new_losvd,
-                                       normalise=False)
+        new_orblib = dyn_kin.Histogram(xedg=orblib.xedg, y=new_losvd)
         return new_orblib
 
     def duplicate_flip_and_interlace_intmoms(self, intmom):
@@ -1053,9 +1047,7 @@ class LegacyOrbitLibrary(OrbitLibrary):
                               n_spatial_bins1))
         new_losvd[:n_orbs1] = orblib1.y
         new_losvd[n_orbs1:] = orblib2.y
-        new_orblib = dyn_kin.Histogram(xedg=orblib1.xedg,
-                                       y=new_losvd,
-                                       normalise=False)
+        new_orblib = dyn_kin.Histogram(xedg=orblib1.xedg, y=new_losvd)
         return new_orblib
 
     def read_losvd_histograms(self, pops=False):


### PR DESCRIPTION
In issue #229 we identified the `Histogram.normalise()` method to be potentially broken. As that method is currently not used anywhere, we had agreed on removing it.

This PR removes that method and references to it across DYNAMITE (incl. tutorial `6_orbits_and_weights.ipynb` and removing the unused `Histogram.normalised` attribute).

Rationale: code simplification ahead of implementing Histogram2D for future proper motions functionality.

Tested with `test_nnls.py`, `test_notebooks.sh`.

Please run a few tests and if happy, merge :-)

Closes #229