### PR TITLE
Check for zero kin errors before weight solving

### DIFF
--- a/docs/tutorial_notebooks/4_BayesLOSVD.ipynb
+++ b/docs/tutorial_notebooks/4_BayesLOSVD.ipynb
@@ -177,7 +177,7 @@
     "- losvd: array holding the LOSVD \n",
     "- dlosvd: array holding LOSVD uncertainties, given by 68% credible intervals per velocity bin (assumed independent)\n",
     "\n",
-    "BayesLOSVD represents the LOSVD as a sequence of weights. Details of the velocity array are stored as metadata to the data table. Details of the LOSVD velocity array are stored as metadata to the data table,"
+    "BayesLOSVD represents the LOSVD as a sequence of weights. Details of the LOSVD velocity array are stored as metadata to the data table,"
    ]
   },
   {
@@ -649,7 +649,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.11.10"
   }
  },
  "nbformat": 4,

--- a/dynamite/config_reader.py
+++ b/dynamite/config_reader.py
@@ -933,6 +933,10 @@ class Configuration(object):
                                       'BayesLOSVD - use chi2 or kinchi2.'
                                 self.logger.error(txt)
                                 raise ValueError(txt)
+                        else:  # GaussHermite kinematics
+                            # get_data checks for errors >= 0 in chosen moments
+                            _ = kin_data.get_data(
+                                self.settings.weight_solver_settings)
                 else:
                     self.logger.error('VisibleComponent must have kinematics: '
                                       'either GaussHermite or BayesLOSVD')

--- a/dynamite/kinematics.py
+++ b/dynamite/kinematics.py
@@ -295,15 +295,12 @@ class GaussHermite(Kinematics, data.Integrated):
             if cache_data:
                 self._data_with_sys_err = gh_data.copy(copy_data=True)
         bad_err = [(int(bin) + 1, 'dv')
-                   for bin in np.nonzero(gh_data['dv'] <= 0)
-                   if len(bin) > 0]
+                   for bin in np.flatnonzero(gh_data['dv'] <= 0)]
         bad_err += [(int(bin) + 1, 'dsigma')
-                    for bin in np.nonzero(gh_data['dsigma'] <= 0)
-                    if len(bin) > 0]
+                    for bin in np.flatnonzero(gh_data['dsigma'] <= 0)]
         for i in range(3, number_gh + 1):
             bad_err += [(int(bin) + 1, f'dh{i}')
-                        for bin in np.nonzero(gh_data[f'dh{i}'] <= 0)
-                        if len(bin) > 0]
+                        for bin in np.flatnonzero(gh_data[f'dh{i}'] <= 0)]
         if len(bad_err) > 0:
             txt = 'Kinematics uncertainties cannot be zero or negative. ' \
                 'Consider editing the kinematics datafile(s) and/or ' \

--- a/dynamite/kinematics.py
+++ b/dynamite/kinematics.py
@@ -294,20 +294,20 @@ class GaussHermite(Kinematics, data.Integrated):
                               'applied systematic errors.')
             if cache_data:
                 self._data_with_sys_err = gh_data.copy(copy_data=True)
-        zero_err = [(int(bin) + 1, 'dv')
-                    for bin in np.nonzero(gh_data['dv'] == 0)
-                    if len(bin) > 0]
-        zero_err += [(int(bin) + 1, 'dsigma')
-                    for bin in np.nonzero(gh_data['dsigma'] == 0)
+        bad_err = [(int(bin) + 1, 'dv')
+                   for bin in np.nonzero(gh_data['dv'] <= 0)
+                   if len(bin) > 0]
+        bad_err += [(int(bin) + 1, 'dsigma')
+                    for bin in np.nonzero(gh_data['dsigma'] <= 0)
                     if len(bin) > 0]
         for i in range(3, number_gh + 1):
-            zero_err += [(int(bin) + 1, f'dh{i}')
-                         for bin in np.nonzero(gh_data[f'dh{i}'] == 0)
-                         if len(bin) > 0]
-        if len(zero_err) > 0:
-            txt = 'Kinematics uncertainties cannot be zero, consider editing '
-            txt += 'the kinematics datafile(s) and/or GH_sys_err. Violating '
-            txt += f'vbin_id / data_id pair(s): {zero_err}.'
+            bad_err += [(int(bin) + 1, f'dh{i}')
+                        for bin in np.nonzero(gh_data[f'dh{i}'] <= 0)
+                        if len(bin) > 0]
+        if len(bad_err) > 0:
+            txt = 'Kinematics uncertainties cannot be zero or negative. ' \
+                'Consider editing the kinematics datafile(s) and/or ' \
+                f'GH_sys_err. Violating vbin_id / data_id pair(s): {bad_err}.'
             self.logger.error(txt)
             raise ValueError(txt)
         return gh_data
@@ -1020,10 +1020,10 @@ class BayesLOSVD(Kinematics, data.Integrated):
             self.data.remove_column(f'losvd_{j}')
             losvd_sigma[:,j] = self.data[f'dlosvd_{j}']
             self.data.remove_column(f'dlosvd_{j}')
-        zero_err = np.nonzero(losvd_sigma == 0)
-        if len(zero_err[0]) > 0:
-            txt = 'Kinematics uncertainties cannot be zero. Violating '
-            txt += f'binID / vbin pair(s): {list(zip(*zero_err))}.'
+        bad_err = np.nonzero(losvd_sigma <= 0)
+        if len(bad_err[0]) > 0:
+            txt = 'Kinematics uncertainties cannot be zero or negative. '
+            txt += f'Violating binID / vbin pair(s): {list(zip(*bad_err))}.'
             self.logger.error(txt)
             raise ValueError(txt)
         self.data['losvd'] = losvd_mean

--- a/dynamite/kinematics.py
+++ b/dynamite/kinematics.py
@@ -294,6 +294,22 @@ class GaussHermite(Kinematics, data.Integrated):
                               'applied systematic errors.')
             if cache_data:
                 self._data_with_sys_err = gh_data.copy(copy_data=True)
+        zero_err = [(int(bin) + 1, 'dv')
+                    for bin in np.nonzero(gh_data['dv'] == 0)
+                    if len(bin) > 0]
+        zero_err += [(int(bin) + 1, 'dsigma')
+                    for bin in np.nonzero(gh_data['dsigma'] == 0)
+                    if len(bin) > 0]
+        for i in range(3, number_gh + 1):
+            zero_err += [(int(bin) + 1, f'dh{i}')
+                         for bin in np.nonzero(gh_data[f'dh{i}'] == 0)
+                         if len(bin) > 0]
+        if len(zero_err) > 0:
+            txt = 'Kinematics uncertainties cannot be zero, consider editing '
+            txt += 'the kinematics datafile(s) and/or GH_sys_err. Violating '
+            txt += f'vbin_id / data_id pair(s): {zero_err}.'
+            self.logger.error(txt)
+            raise ValueError(txt)
         return gh_data
 
     def has_pops(self):
@@ -1004,6 +1020,12 @@ class BayesLOSVD(Kinematics, data.Integrated):
             self.data.remove_column(f'losvd_{j}')
             losvd_sigma[:,j] = self.data[f'dlosvd_{j}']
             self.data.remove_column(f'dlosvd_{j}')
+        zero_err = np.nonzero(losvd_sigma == 0)
+        if len(zero_err[0]) > 0:
+            txt = 'Kinematics uncertainties cannot be zero. Violating '
+            txt += f'binID / vbin pair(s): {list(zip(*zero_err))}.'
+            self.logger.error(txt)
+            raise ValueError(txt)
         self.data['losvd'] = losvd_mean
         self.data['dlosvd'] = losvd_sigma
 


### PR DESCRIPTION
In case any of the kinematics errors are zero, DYNAMITE would crash upon weight solving with non-helpful error messages. Finding the cause of the crash proved difficult.

This PR checks for zero kinematics errors before weight solving and issues an error message that points exactly to the problematic kinematics data elements.

Tested with
- `test_notebooks.sh`: runs successfully
- `test_nnls.py`, unchanged data: runs successfully
- `test_nnls.py`, some random errors in `NGC6278_input/gauss_hermite_kins.ecsv` set to zero: issues an error message pointing to each of the locations of the zeros in the datafile before crashing
- BayesLOSVD tutorial `4_BayesLOSVD.ipynb`, unchanged data: runs successfully
- BayesLOSVD tutorial `4_BayesLOSVD.ipynb`, some random errors in `NGC4550_input/dynamite_input/bayes_losvd_kins.ecsv` set to zero AND in the notebook's first coding cell, change from
`BayesLOSVD.write_losvds_to_ecsv_format(infile, outfile=outfile)`
to
`# BayesLOSVD.write_losvds_to_ecsv_format(infile, outfile=outfile)`
issues an error message pointing to each of the locations of the zeros in the datafile before crashing