### PR TITLE
Bugfix for bar and histograms in general

### DIFF
--- a/dev_tests/bartest.yaml
+++ b/dev_tests/bartest.yaml
@@ -153,7 +153,7 @@ system_components:
                 type: GaussHermite # specifies which object class to create
                 hist_width: '1578.6020507812'
                 hist_center: '0.0000'
-                hist_bins: '476'
+                hist_bins: '477'
                 datafile: "kinematics.ecsv"  # both discr. & integrated
                 aperturefile: "aperture.dat" # integrated only
                 binfile: "bins.dat"          # integrated only

--- a/dynamite/config_reader.py
+++ b/dynamite/config_reader.py
@@ -356,7 +356,7 @@ class Configuration(object):
                     if 'disk_lum' in data_comp:
                         path = self.settings.io_settings['input_directory']
                         c.disk_lum = mge.MGE(input_directory=path,
-                                             datafile=data_comp['disk_pot'])
+                                             datafile=data_comp['disk_lum'])
 
                     # add component to system
                     c.validate()


### PR DESCRIPTION
After test_bar.py failed and some debugging, the following flaws were fixed. Two of them are bar-specific, one affects DYNAMITE in general:
- Bugfix: the `disk_lum` property of the BarDisk should actually be filled from the file linked to the `disk_lum` entry in the config file, not `disk_pot`. This has been fixed.
- Bugfix: `test_bar.py` (not bartest.py as erroneously written in the commit message) crashed after orbit integration, complaining about an odd number of velocity histogram bins. This has been fixed by an appropriate entry in the config file `bartest.yaml`.
- To avoid wasting considerable computation time until errors pertaining to even numbers of velocity histogram bins cause DYNAMITE to crash, an appropriate check was implemented in the config_reader. Now, DYNAMITE crashes while reading the config file, pointing the user to the specific problem in the config data.

Tested:
- Successfully executed `test_nnls.py`, `test_bar.py`, and `test_notebooks.sh`.
- In `bartest.yaml`, replace `hist_bins: '477'` by `hist_bins: '476'` (line 156) and re-run `test_bar.py`. Upon reading the config file, DYNAMITE should crash and tell the user
`ValueError: Value of hist_bins must be odd for all kinematic data, but they are {'kinset1': 476}.`
- In `user_test_config_ml.yaml`, replace `hist_bins: '203'` by `hist_bins: '204'` (line 118) and re-run `test_nnls.py`. Upon reading the config file, DYNAMITE should crash and tell the user
`ValueError: Value of hist_bins must be odd for all kinematic data, but they are {'kinset1': 204}.`

Please test, too - any feedback is welcome!