### PR TITLE
Adopt H_0=70 throughout DYNAMITE

### DIFF
--- a/docs/getting_started/configuration.rst
+++ b/docs/getting_started/configuration.rst
@@ -82,6 +82,8 @@ This section lists the following attributes of the system::
       distMPc: ...        # distance in MPc
       name:  ...          # name for your galaxy
 
+Note: DYNAMITE assumes :math:`H_0 = 70\;\mathrm{km/s/Mpc}` and that the system is at zero redshift :math:`z=0`. An extension to different cosmologies and system redshifts may be implemented at a later point.
+
 ``system_components``
 =====================
 

--- a/docs/getting_started/configuration.rst
+++ b/docs/getting_started/configuration.rst
@@ -82,7 +82,7 @@ This section lists the following attributes of the system::
       distMPc: ...        # distance in MPc
       name:  ...          # name for your galaxy
 
-Note: DYNAMITE assumes :math:`H_0 = 70\;\mathrm{km/s/Mpc}` and that the system is at zero redshift :math:`z=0`. An extension to different cosmologies and system redshifts may be implemented at a later point.
+Note: DYNAMITE assumes a value of :math:`H_0 = 70\;\mathrm{km/s/Mpc}` which is often used in the literature. Also, the system is assumed at zero redshift :math:`z=0`. An extension to different cosmologies and system redshifts may be implemented at a later point.
 
 ``system_components``
 =====================

--- a/docs/more_info/changelog.rst
+++ b/docs/more_info/changelog.rst
@@ -4,6 +4,7 @@
 Change Log
 ****************
 
+- Improvement: DYNAMITE now consistently uses :math:`H_0 = 70\;\mathrm{km/s/Mpc}`.
 - Improvement: Avoid confusing warnings when creating decomposition plots.
 - Improvement: Added the optional `fig_height` keyword argument to plotting Gauss Hermite kinematic maps, adjusting the plot height (and aspect ratio).
 - Bugfix: Fixed a bug that caused ``System.get_all_kinematic_data()`` to return only the first component's kinematic data.

--- a/dynamite/constants.py
+++ b/dynamite/constants.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-H0 = 73. # km/s/Mpc, used in Fortran
+H0 = 70. # km/s/Mpc, used in Fortran
 
 GRAV_CONST_KM = 6.67428e-11*1.98892e30/1e9
 PARSEC_KM = 1.4959787068e8*(648.000e3/np.pi)

--- a/dynamite/physical_system.py
+++ b/dynamite/physical_system.py
@@ -1219,7 +1219,7 @@ class NFW_m200_c(DarkComponent):
         stars = system.get_component_from_class(TriaxialVisibleComponent)
         M_stars_tot = stars.get_M_stars_tot(system.distMPc, parset)
         f = parset[f'f-{self.name}']
-        h = 0.671 #add paper
+        h = dyn.constants.H0 / 100
         #total mass of dark matter
         MvDM = f * M_stars_tot
         #dutton&maccio2014 (https://arxiv.org/pdf/1402.7073.pdf) Eq. (8)
@@ -1420,9 +1420,6 @@ class GeneralisedNFW(DarkComponent):
         c = par['c']
         gam = par['gam']
 
-        # H0 = 73                                    # km/s/Mpc, used in Fortran
-        # G = 4.3009172706e-3                        # pc/Msun⋅(km/s)**2
-        # rho_crit = 3 * H0**2 * 1e-12 / (8*np.pi*G) # Msun/pc**3
         rho_crit = dyn.constants.RHO_CRIT * dyn.constants.PARSEC_KM ** 3
 
         r200 = (3 * Mvir / (800 * np.pi * rho_crit))**(1.0 / 3.0)

--- a/dynamite/plotter.py
+++ b/dynamite/plotter.py
@@ -13,7 +13,6 @@ import matplotlib as mpl
 from matplotlib.ticker import MaxNLocator, FixedLocator,LogLocator
 from matplotlib.ticker import NullFormatter
 import matplotlib.pyplot as plt
-import astropy
 from plotbin import display_pixels
 from dynamite import constants
 from dynamite import kinematics
@@ -1007,9 +1006,7 @@ class Plotter():
         #Input parameters: NFW dark matter concentration and fraction,
         #and stellar mass
 
-        grav_const_km = 6.67428e-11*1.98892e30/1e9
-        parsec_km = 1.4959787068e8*(648.000e3/np.pi)
-        rho_crit = (3.*((7.3000e-5)/parsec_km)**2)/(8.*np.pi*grav_const_km)
+        rho_crit = constants.RHO_CRIT
 
         rhoc = (200./3.)*rho_crit*cc**3/(np.log(1.+cc) - cc/(1.+cc))
         rc = (3./(800.*np.pi*rho_crit*cc**3)*dmfrac*mstars)**(1./3.)

--- a/legacy_fortran/iniparam_f.f90
+++ b/legacy_fortran/iniparam_f.f90
@@ -81,7 +81,7 @@ module initial_parameters
     real(kind=dp), parameter, public :: &
         grav_const_km = 6.67428e-11_dp*1.98892e30_dp/1e9_dp, &
         parsec_km = 1.4959787068d8*(648d3/pi_d), &
-        rho_crit = (3.0_dp*(7.3d-5/parsec_km)**2)/(8.0_dp*pi_d*grav_const_km)
+        rho_crit = (3.0_dp*(7.0d-5/parsec_km)**2)/(8.0_dp*pi_d*grav_const_km)
 
     private ! default private
     public :: iniparam, iniparam_bar


### PR DESCRIPTION
This PR adopts $H_0=70\ km/s/Mpc$ throughout DYNAMITE, a value often used in the literature.

In the documentation, an according note was added to the `Configuration -> system_attributes` section, along with mentioning that as of now, DYNAMITE systems are assumed at zero redshift.

Closes #362

This PR is ready for testing and merging.
Test suggestion: run `test_nnls.py`, `test_notebooks.sh`, and have a brief look at the changed code to verify.