### PR TITLE
Check for right bar-disk system variant on startup

### DIFF
--- a/dev_tests/bartest.yaml
+++ b/dev_tests/bartest.yaml
@@ -136,7 +136,7 @@ system_components:
                 fixed: True
                 value: 90.0
                 LaTeX: "$\\psi$"
-        type: "BarDiskComponentAngles" # class name
+        type: "BarDiskComponent" # class name
         mge_pot: "bar_mge.ecsv"
         mge_lum: "bar_mge.ecsv"
         disk_pot: "disk_mge.ecsv"

--- a/dev_tests/bartest.yaml
+++ b/dev_tests/bartest.yaml
@@ -196,10 +196,10 @@ orblib_settings:
     random_seed: 4242 # integer; any value <= 0 results in stochastic seed
 
 weight_solver_settings:
-    type: "LegacyWeightSolver"
-    nnls_solver: 1
-    # type: "NNLS"
-    # nnls_solver: 'scipy'
+    # type: "LegacyWeightSolver"
+    # nnls_solver: 1
+    type: "NNLS"
+    nnls_solver: 'scipy'
     maxiter_factor: 3  # nnls_solver 'scipy' only; default: 3
     CRcut: True
     regularisation: 0

--- a/dynamite/config_reader.py
+++ b/dynamite/config_reader.py
@@ -954,8 +954,16 @@ class Configuration(object):
 
         if self.system.is_bar_disk_system():
             if self.system.number_of_bar_components() != 1:
-                self.logger.error('Bar/disk system needs to have exactly one BarDiskComponent object')
-                raise ValueError('Bar/disk system needs to have exactly one BarDiskComponent object')
+                txt = 'Bar/disk system needs to have exactly one ' \
+                      'BarDiskComponent object'
+                self.logger.error(txt)
+                raise ValueError(txt)
+            if not self.system.is_bar_disk_system_with_angles():
+                txt = 'Bar/disk system must be of type BarDiskComponentAngles'\
+                      ', type BarDiskComponent with q, p, u, qdisk not yet ' \
+                      'implemented.'
+                self.logger.error(txt)
+                raise ValueError(txt)
         else:
             if self.system.number_of_visible_components() != 1:
                 self.logger.error('System needs to have exactly one '

--- a/dynamite/config_reader.py
+++ b/dynamite/config_reader.py
@@ -958,12 +958,7 @@ class Configuration(object):
                       'BarDiskComponent object'
                 self.logger.error(txt)
                 raise ValueError(txt)
-            if not self.system.is_bar_disk_system_with_angles():
-                txt = 'Bar/disk system must be of type BarDiskComponentAngles'\
-                      ', type BarDiskComponent with q, p, u, qdisk not yet ' \
-                      'implemented.'
-                self.logger.error(txt)
-                raise ValueError(txt)
+
         else:
             if self.system.number_of_visible_components() != 1:
                 self.logger.error('System needs to have exactly one '

--- a/dynamite/mges.py
+++ b/dynamite/mges.py
@@ -828,18 +828,9 @@ class MGE(data.Data):
         # used to derive the viewing angles
         parset = model.parset
         if self.config.system.is_bar_disk_system():
-            if self.config.system.is_bar_disk_system_with_angles():
-                theta_view = parset[f'theta-{stars.name}']
-                phi_view = parset[f'phi-{stars.name}']
-                psi_view = parset[f'psi-{stars.name}']
-            else:
-                q = parset[f'q-{stars.name}']
-                p = parset[f'p-{stars.name}']
-                u = parset[f'u-{stars.name}']
-                qdisk = parset[f'qdisk-{stars.name}']
-                theta_view, psi_view, phi_view = \
-                    stars.triax_pqu2tpp_bar(p, q, u, qdisk)
-                phi_view = -phi_view ## FIX ME
+            theta_view = parset[f'theta-{stars.name}']
+            phi_view = parset[f'phi-{stars.name}']
+            psi_view = parset[f'psi-{stars.name}']
         else:
             q = parset[f'q-{stars.name}']
             p = parset[f'p-{stars.name}']

--- a/dynamite/orblib.py
+++ b/dynamite/orblib.py
@@ -156,12 +156,15 @@ class LegacyOrbitLibrary(OrbitLibrary):
                 phi = self.parset[f'phi-{stars.name}']
                 psi = self.parset[f'psi-{stars.name}']
             else:
+                # Bar-disk systems with q, p, u, qdisk are
+                # NOT YET IMPLEMENTED. The config reader checks this, so this
+                # else-branch should never be encountered.
                 q = self.parset[f'q-{stars.name}']
                 p = self.parset[f'p-{stars.name}']
                 u = self.parset[f'u-{stars.name}']
                 qdisk = self.parset[f'qdisk-{stars.name}']
-                theta, psi, phi = stars.triax_pqu2tpp_bar(p,q,u,qdisk)
-                phi = -phi ## FIX ME
+                theta, psi, phi = stars.triax_pqu2tpp_bar(p,q,u,qdisk)  # TO DO
+                phi = -phi  # FIX ME
         else:
             q = self.parset[f'q-{stars.name}']
             p = self.parset[f'p-{stars.name}']

--- a/dynamite/orblib.py
+++ b/dynamite/orblib.py
@@ -151,20 +151,9 @@ class LegacyOrbitLibrary(OrbitLibrary):
         bh = self.system.get_component_from_class(physys.Plummer)
         # used to derive the viewing angles
         if self.system.is_bar_disk_system():
-            if self.system.is_bar_disk_system_with_angles():
-                theta = self.parset[f'theta-{stars.name}']
-                phi = self.parset[f'phi-{stars.name}']
-                psi = self.parset[f'psi-{stars.name}']
-            else:
-                # Bar-disk systems with q, p, u, qdisk are
-                # NOT YET IMPLEMENTED. The config reader checks this, so this
-                # else-branch should never be encountered.
-                q = self.parset[f'q-{stars.name}']
-                p = self.parset[f'p-{stars.name}']
-                u = self.parset[f'u-{stars.name}']
-                qdisk = self.parset[f'qdisk-{stars.name}']
-                theta, psi, phi = stars.triax_pqu2tpp_bar(p,q,u,qdisk)  # TO DO
-                phi = -phi  # FIX ME
+            theta = self.parset[f'theta-{stars.name}']
+            phi = self.parset[f'phi-{stars.name}']
+            psi = self.parset[f'psi-{stars.name}']
         else:
             q = self.parset[f'q-{stars.name}']
             p = self.parset[f'p-{stars.name}']

--- a/dynamite/physical_system.py
+++ b/dynamite/physical_system.py
@@ -343,7 +343,8 @@ class System(object):
     def is_bar_disk_system(self):
         """is_bar_disk_system
 
-        Check if the system contains at least one bar component and at least one disk component.
+        Check if the system contains at least one bar component and at least
+        one disk component.
 
         Returns
         -------
@@ -356,14 +357,16 @@ class System(object):
     def is_bar_disk_system_with_angles(self):
         """is_bar_disk_system_with_angles
 
-        Check if the system is a bar-disk with phi, psi, theta specified directly in the configuration file.
+        Check if the system is a bar-disk with phi, psi, theta specified
+        directly in the configuration file.
 
         Returns
         -------
         hasangles : Bool
             System is specified by angles.
         """
-        hasangles = self.is_bar_disk_system() and (type(self.get_unique_bar_component()) is BarDiskComponentAngles)
+        hasangles = self.is_bar_disk_system() and \
+            (type(self.get_unique_bar_component()) is BarDiskComponentAngles)
         return hasangles
 
     def number_of_visible_components(self):

--- a/dynamite/physical_system.py
+++ b/dynamite/physical_system.py
@@ -354,21 +354,6 @@ class System(object):
         isbardisk = len(self.get_all_bar_components()) > 0
         return isbardisk
 
-    def is_bar_disk_system_with_angles(self):
-        """is_bar_disk_system_with_angles
-
-        Check if the system is a bar-disk with phi, psi, theta specified
-        directly in the configuration file.
-
-        Returns
-        -------
-        hasangles : Bool
-            System is specified by angles.
-        """
-        hasangles = self.is_bar_disk_system() and \
-            (type(self.get_unique_bar_component()) is BarDiskComponentAngles)
-        return hasangles
-
     def number_of_visible_components(self):
         return sum(1 for i in self.cmp_list if isinstance(i, VisibleComponent))
 
@@ -1004,24 +989,6 @@ class TriaxialVisibleComponent(VisibleComponent):
 
 
 class BarDiskComponent(TriaxialVisibleComponent):
-    """Rotating triaxial component with a MGE projected density (i.e. a bar)
-
-    Note: all bar components are constrained to have the same omega.
-
-    """
-    def __init__(self,
-                 mge_pot=None,
-                 mge_lum=None,
-                 disk_pot=None,
-                 disk_lum=None,
-                 **kwds):
-        super().__init__(**kwds)
-        self.logger = logging.getLogger(f'{__name__}.{__class__.__name__}')
-        self.qobs = np.nan
-        self.par = ['q', 'p', 'u', 'qdisk']
-
-
-class BarDiskComponentAngles(BarDiskComponent):
     """Rotating triaxial component with a MGE projected density (i.e. a bar),
     with viewing angles specified.
 


### PR DESCRIPTION
Check for bar-disk systems with tpp ($\theta$, $\psi$, $\phi$) angles and reject the (not implemented) q, p, u, qdisk parameters upon reading the config file.

Closes #516

Testing: this is a very small PR, running `test_bar.py` and `test_nnls.py` should suffice.