### PR TITLE
Allow NumPy versions >= 2

### DIFF
--- a/docs/more_info/changelog.rst
+++ b/docs/more_info/changelog.rst
@@ -4,6 +4,7 @@
 Change Log
 ****************
 
+- Improvement: Reconfirmed DYNAMITE compatibility with numpy 2.x.
 - Improvement: Avoid confusing warnings when creating decomposition plots.
 - Improvement: Added the optional `fig_height` keyword argument to plotting Gauss Hermite kinematic maps, adjusting the plot height (and aspect ratio).
 - Bugfix: Fixed a bug that caused ``System.get_all_kinematic_data()`` to return only the first component's kinematic data.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cmasher>=1.6.0
 h5py>=3.1.0
 lmfit
 matplotlib>=3.5.3
-numpy>=1.21.6,<1.27.0
+numpy>=1.26
 pafit>=2.0.8
 pathos>=0.2.7
 plotbin>=3.1.7


### PR DESCRIPTION
With NumPy 1.26 having reached [end-of-life on 9/17/2025,](https://endoflife.date/numpy) this PR opens DYNAMITE to NumPy versions >= 2.0.
- As NumPy 2.0 involves some major changes, the requirements also allow the last 1.x release (NumPy 1.26) for users who cannot update to NumPy 2.

Earlier work on making DYNAMITE NumPy 2.x compliant payed off - the following tests succeeded with Python 3.13.5 and NumPy 2.3.5:
- Followed the instructions in the [NumPy 2.0 migration guide](https://numpy.org/devdocs/numpy_2_0_migration_guide.html), including inspecting code and running the Ruff check on the entire DYNAMITE Python codebase.
- Running the 'standard' test configuration `user_test_config_ml.yaml`, followed by creating each plot in `plotter.py` in a notebook.
- Executing the external chi2 test (run `test_nnls.py` with configuration file `user_test_config_ml_gas.yaml`).
- Run the Python test scripts `test_nnls.py`, `test_bar.py`, `test_decomp.py`, `test_orbit_losvds.py`, `dif_dm_halos.py`.
- Run the shell scripts `test_notebooks.sh`, `test_all.sh`.

Installation instructions:
either change `numpy>=1.26` to `numpy>=2` in `requirements.txt`
or delete numpy via `python -m pip uninstall numpy` before installing DYNAMITE.

Please test with your own Python version and DYNAMITE model...