### PR TITLE
Fixes for Python projected and intrinsic mass calculations

### DIFF
--- a/dynamite/config_reader.py
+++ b/dynamite/config_reader.py
@@ -9,6 +9,7 @@ import importlib
 import yaml
 
 from datetime import datetime, timezone
+from astropy import table
 
 import dynamite as dyn
 from dynamite import constants as const
@@ -576,14 +577,21 @@ class Configuration(object):
         self.all_models.update_model_table()
 
         if self.settings.weight_solver_settings['type']!='LegacyWeightSolver':
+            p_mass_fname = self.settings.io_settings['output_directory'] + \
+                           const.p_masses_file
+            stars = self.system.get_unique_triaxial_visible_component()
+            if os.path.isfile(p_mass_fname):
+                n_bins = sum([max(k.dp_args['idx_bin_to_pix']) + 1
+                            for k in stars.kinematic_data])
+                proj_mass = table.Table.read(p_mass_fname, format='ascii')
+                if n_bins != len(proj_mass):
+                    self.logger.warning('Removing existing projected masses '
+                                        'file due to spatial bin mismatch.')
+                    self.remove_projected_masses_file()
             if self.system.is_bar_disk_system():
-                bardisk = self.system.get_unique_bar_component()
-                bardisk.mass_aper = None
-                bardisk.mge_lum_tot = bardisk.mge_lum + bardisk.disk_lum
-                bardisk.mass_aper = bardisk.mge_lum_tot.get_projected_masses()
+                stars.mge_lum_tot = stars.mge_lum + stars.disk_lum
+                stars.mass_aper = stars.mge_lum_tot.get_projected_masses()
             else:
-                stars = self.system.get_unique_triaxial_visible_component()
-                stars.mass_aper = None
                 stars.mass_aper = stars.mge_lum.get_projected_masses()
 
         # self.backup_config_file(reset=False)

--- a/dynamite/model.py
+++ b/dynamite/model.py
@@ -38,6 +38,7 @@ class AllModels(object):
             stars = config.system.get_unique_bar_component()
         else:
             stars = config.system.get_unique_triaxial_visible_component()
+        self.has_losvd_kins = len(stars.kinematic_data)
         self.has_pops = len([p for p in stars.population_data
                              if p.kin_aper is None]) > 0
         self.has_pms = False  # fill in after implementing proper motions
@@ -305,9 +306,22 @@ class AllModels(object):
                 and os.path.isfile(d + 'orblibbox.dat.bz2')
         if not check:
             check = os.path.isfile(d + 'orblib_qgrid.dat.bz2') \
-                    and os.path.isfile(d + 'orblib_losvd_hist.dat.bz2') \
-                    and os.path.isfile(d + 'orblibbox_qgrid.dat.bz2') \
-                    and os.path.isfile(d + 'orblibbox_losvd_hist.dat.bz2')
+                    and os.path.isfile(d + 'orblibbox_qgrid.dat.bz2')
+            orblib_files_ok = orblib_files_ok and check
+            # check for 'regular' losvd kinematics
+            if self.has_losvd_kins:
+                check = os.path.isfile(d + 'orblib_losvd_hist.dat.bz2') \
+                        and os.path.isfile(d + 'orblibbox_losvd_hist.dat.bz2')
+                orblib_files_ok = orblib_files_ok and check
+        # additional files from orblib integration
+        extra_files = ['orblib.dat_orbclass.out', 'orblibbox.dat_orbclass.out']
+        ws_type = self.config.settings.weight_solver_settings['type']
+        if ws_type == 'LegacyWeightSolver':
+            extra_files += ['mass_radmass.dat', 'mass_qgrid.dat',
+                            'mass_aper.dat']
+        else:
+            extra_files += ['mass_radmass.ecsv', 'mass_qgrid.ecsv']
+        check = all([os.path.isfile(d + f) for f in extra_files])
         orblib_files_ok = orblib_files_ok and check
         # files that need to be there if populations with own apertures exist
         if self.has_pops:

--- a/dynamite/physical_system.py
+++ b/dynamite/physical_system.py
@@ -543,6 +543,7 @@ class VisibleComponent(Component):
          # visible components have MGE surface density
         self.mge_pot = mge_pot
         self.mge_lum = mge_lum
+        self.mass_aper = None
         super().__init__(visible=True, **kwds)
         self.logger = logging.getLogger(f'{__name__}.{__class__.__name__}')
 


### PR DESCRIPTION
Intrinsic masses bugfix:
- Upon restarting DYNAMITE, `AllModels.update_orblib_flags()` flagged orblibs for recalculation if the intrinsic masses were calculated by the new Python code, thus causing a significant performance issue. This PR fixes it.

Projected masses improvements:
- After reading the config file, if a projected mass file exists, check whether the spatial bins in that file are compatible with those in the kinematics sets just read from the config file. If not, recalculate the projected masses.
- Cleaned up the implementation of the `VisibleComponent.mass_aper` attribute (properly defined in the component's class rather than in the config reader code).

Tested `test_notebooks.sh` and `test_nnls.py`, the latter with the standard config as well as a non-public multiple-kinematics dataset.
