### PR TITLE
Use get_unique_triaxial_visible_component() for bar systems, too.

### DIFF
--- a/dynamite/analysis.py
+++ b/dynamite/analysis.py
@@ -209,10 +209,7 @@ class Decomposition:
 
         """
         mpl.rcParams['savefig.dpi'] = dpi
-        if self.config.system.is_bar_disk_system():
-            stars = self.config.system.get_unique_bar_component()
-        else:
-            stars = self.config.system.get_unique_triaxial_visible_component()
+        stars = self.config.system.get_unique_triaxial_visible_component()
         n_kin = len(stars.kinematic_data)
         if kin_set >= n_kin:
             text = f'kin_set must be < {n_kin}, but it is {kin_set}'
@@ -742,10 +739,7 @@ class Analysis:
             raise ValueError(txt)
         if model is None:
             model = self.model
-        if self.config.system.is_bar_disk_system():
-            stars = self.config.system.get_unique_bar_component()
-        else:
-            stars = self.config.system.get_unique_triaxial_visible_component()
+        stars = self.config.system.get_unique_triaxial_visible_component()
         if isinstance(kin_set, int) or (kin_set is None and pop_set is None):
             if kin_set is None:
                 kin_set = self.kin_set
@@ -915,10 +909,7 @@ class Analysis:
                    "'both'."
             self.logger.error(txt)
             raise ValueError(txt)
-        if self.config.system.is_bar_disk_system():
-            stars = self.config.system.get_unique_bar_component()
-        else:
-            stars = self.config.system.get_unique_triaxial_visible_component()
+        stars = self.config.system.get_unique_triaxial_visible_component()
         kin_name = stars.kinematic_data[kin_set].name
         self.logger.info('Getting projected masses and losvds for kinematics '
                          f'{kin_name} and model {model.directory}.')

--- a/dynamite/coloring.py
+++ b/dynamite/coloring.py
@@ -1635,10 +1635,7 @@ class Coloring:
         else:
             plot_cols = [col for col in pop_data]
         # Get the observed data
-        if self.config.system.is_bar_disk_system():
-            stars = self.config.system.get_unique_bar_component()
-        else:
-            stars = self.config.system.get_unique_triaxial_visible_component()
+        stars = self.config.system.get_unique_triaxial_visible_component()
         pops = stars.population_data[0]
         map_plotter = pops.get_map_plotter()
         pop_data_obs = pops.get_data()  # observed population data

--- a/dynamite/config_reader.py
+++ b/dynamite/config_reader.py
@@ -576,14 +576,12 @@ class Configuration(object):
         self.all_models.update_model_table()
 
         if self.settings.weight_solver_settings['type']!='LegacyWeightSolver':
+            stars = self.system.get_unique_triaxial_visible_component()
+            stars.mass_aper = None
             if self.system.is_bar_disk_system():
-                bardisk = self.system.get_unique_bar_component()
-                bardisk.mass_aper = None
-                bardisk.mge_lum_tot = bardisk.mge_lum + bardisk.disk_lum
-                bardisk.mass_aper = bardisk.mge_lum_tot.get_projected_masses()
+                stars.mge_lum_tot = stars.mge_lum + stars.disk_lum
+                stars.mass_aper = stars.mge_lum_tot.get_projected_masses()
             else:
-                stars = self.system.get_unique_triaxial_visible_component()
-                stars.mass_aper = None
                 stars.mass_aper = stars.mge_lum.get_projected_masses()
 
         # self.backup_config_file(reset=False)
@@ -1133,10 +1131,7 @@ class Configuration(object):
                 for k in stars.kinematic_data:
                     k.hist_bins = max_bins
         else:  # enforce odd number of histogram bins
-            if self.system.is_bar_disk_system():
-                stars = self.system.get_unique_bar_component()
-            else:
-                stars = self.system.get_unique_triaxial_visible_component()
+            stars = self.system.get_unique_triaxial_visible_component()
             hist_bins = [k.hist_bins % 2 for k in stars.kinematic_data]
             if any([h == 0 for h in hist_bins]):
                 all_hist_bins = {k.name: k.hist_bins

--- a/dynamite/mges.py
+++ b/dynamite/mges.py
@@ -144,10 +144,7 @@ class MGE(data.Data):
             None, and the projected mass file doesn't exist.
         """
         c = self.config
-        if c.system.is_bar_disk_system():
-            vis_comp = c.system.get_unique_bar_component()
-        else:
-            vis_comp = c.system.get_unique_triaxial_visible_component()
+        vis_comp = c.system.get_unique_triaxial_visible_component()
         if (use_cache or nocalc) and (vis_comp.mass_aper is not None):
             self.logger.info('Projected masses grabbed from vis. component.')
             return vis_comp.mass_aper  ########################################
@@ -821,10 +818,7 @@ class MGE(data.Data):
         Tuple (theta_view, psi_view, phi_view)
             The viewing angels are returned in degrees.
         """
-        if self.config.system.is_bar_disk_system():
-            stars = self.config.system.get_unique_bar_component()
-        else:
-            stars = self.config.system.get_unique_triaxial_visible_component()
+        stars = self.config.system.get_unique_triaxial_visible_component()
         # used to derive the viewing angles
         parset = model.parset
         if self.config.system.is_bar_disk_system():

--- a/dynamite/model.py
+++ b/dynamite/model.py
@@ -34,10 +34,7 @@ class AllModels(object):
             raise ValueError(text)
         self.config = config
         self.system = config.system
-        if config.system.is_bar_disk_system():
-            stars = config.system.get_unique_bar_component()
-        else:
-            stars = config.system.get_unique_triaxial_visible_component()
+        stars = config.system.get_unique_triaxial_visible_component()
         self.has_pops = len([p for p in stars.population_data
                              if p.kin_aper is None]) > 0
         self.has_pms = False  # fill in after implementing proper motions

--- a/dynamite/orblib.py
+++ b/dynamite/orblib.py
@@ -101,10 +101,7 @@ class LegacyOrbitLibrary(OrbitLibrary):
         if not os.path.isfile(self.mod_dir + 'datfil/tube_box_done'):
             # prepare the fortran input files for orblib
             self.create_fortran_input_orblib(self.mod_dir+'infil/')
-            if self.system.is_bar_disk_system():
-                stars = self.system.get_unique_bar_component()
-            else:
-                stars = self.system.get_unique_triaxial_visible_component()
+            stars = self.system.get_unique_triaxial_visible_component()
             # create the kinematics and populations input files for each
             # kinematic dataset and population dataset with own apertures
             pops = [p for p in stars.population_data if p.kin_aper is None]
@@ -133,7 +130,6 @@ class LegacyOrbitLibrary(OrbitLibrary):
                 # Calculate the orblib's parset's observed intrinsic masses
                 model=self.config.all_models.get_model_from_parset(self.parset)
                 if self.system.is_bar_disk_system():
-                    stars = self.system.get_unique_bar_component()
                     mge = stars.mge_lum_tot
                     len_mge_bulge = len(stars.mge_lum.data)
                     # intrinsic masses
@@ -141,7 +137,6 @@ class LegacyOrbitLibrary(OrbitLibrary):
                                                  len_mge_bulge=len_mge_bulge,
                                                  parallel=False)
                 else:
-                    stars = self.system.get_unique_triaxial_visible_component()
                     mge = stars.mge_lum
                     # intrinsic masses
                     _ = mge.get_intrinsic_masses(model, parallel=False)
@@ -173,10 +168,7 @@ class LegacyOrbitLibrary(OrbitLibrary):
         #---------------------------------------------
         #write parameters_pot.in and parameters_lum.in
         #---------------------------------------------
-        if self.system.is_bar_disk_system():
-            stars = self.system.get_unique_bar_component()
-        else:
-            stars = self.system.get_unique_triaxial_visible_component()
+        stars = self.system.get_unique_triaxial_visible_component()
         bh = self.system.get_component_from_class(physys.Plummer)
         # used to derive the viewing angles
         if self.system.is_bar_disk_system():
@@ -799,10 +791,7 @@ class LegacyOrbitLibrary(OrbitLibrary):
         list contains the bin edges of the 3D grid.
 
         """
-        if self.system.is_bar_disk_system():
-            stars = self.system.get_unique_bar_component()
-        else:
-            stars = self.system.get_unique_triaxial_visible_component()
+        stars = self.system.get_unique_triaxial_visible_component()
         norb = self.settings['nE'] * self.settings['nI2'] * self.settings['nI3']
         ml = self.parset['ml']
         cur_dir = os.getcwd()
@@ -1111,10 +1100,7 @@ class LegacyOrbitLibrary(OrbitLibrary):
                 populations data
 
         """
-        if self.system.is_bar_disk_system():
-            stars = self.system.get_unique_bar_component()
-        else:
-            stars = self.system.get_unique_triaxial_visible_component()
+        stars = self.system.get_unique_triaxial_visible_component()
         n_kins = len(stars.kinematic_data)
         n_pops = len(stars.population_data) if pops else 0
 

--- a/dynamite/weight_solvers.py
+++ b/dynamite/weight_solvers.py
@@ -504,11 +504,10 @@ class LegacyWeightSolver(WeightSolver):
         chi2_vector = (np.dot(A, weights) - b)**2.
         chi2_tot = np.sum(chi2_vector)
 
+        stars = self.system.get_unique_triaxial_visible_component()
         if self.system.is_bar_disk_system():
-            bardisk = self.system.get_unique_bar_component()
-            mge = bardisk.mge_lum + bardisk.disk_lum
+            mge = stars.mge_lum + stars.disk_lum
         else:
-            stars = self.system.get_unique_triaxial_visible_component()
             mge = stars.mge_lum
 
         intrinsic_masses = mge.get_intrinsic_masses_from_file(self.direc_no_ml)


### PR DESCRIPTION
This code-cleanup PR unifies the use of the `get_unique_triaxial_visible_component()` and `get_unique_bar_component()` methods (the former includes the latter), reducing code complexity.
- `get_unique_bar_component()` has been removed where possible.
- Tested with `test_nnls.py`, `test_bar.py`, `test_notebooks.sh`