### PR TITLE
allow modelling at z>0

### DIFF
--- a/dev_tests/test_bar.py
+++ b/dev_tests/test_bar.py
@@ -41,7 +41,7 @@ def run_user_test(make_comp=False):
     # c.backup_config_file(keep=3, delete_other=True)
     # c.remove_existing_plots()
 
-    print(f'{const.GRAV_CONST_KM=}, {const.PARSEC_KM=}, {const.RHO_CRIT=}.')
+    print(f'{const.GRAV_CONST_KM=}, {const.PARSEC_KM=}.')
 
     which_chi2 = c.settings.parameter_space_settings['which_chi2']
 

--- a/dev_tests/test_nnls.py
+++ b/dev_tests/test_nnls.py
@@ -43,7 +43,7 @@ def run_user_test(make_comp=False):
     # c.backup_config_file(keep=3, delete_other=True)
     # c.remove_existing_plots()
 
-    print(f'{const.GRAV_CONST_KM=}, {const.PARSEC_KM=}, {const.RHO_CRIT=}.')
+    print(f'{const.GRAV_CONST_KM=}, {const.PARSEC_KM=}')
 
     which_chi2 = c.settings.parameter_space_settings['which_chi2']
 

--- a/docs/getting_started/configuration.rst
+++ b/docs/getting_started/configuration.rst
@@ -143,7 +143,7 @@ The following types of component are available, listed with their parameters:
 - ``NFW``
     - ``c``: concentration parameter [:math:`R_{200}` / NFW-scale-length]
     - ``f``: dark matter fraction [:math:`M_{200}` / total-stellar-mass]
-- ``NFW_m200_c``, an NFW halo with mass-concentration from `Dutton & Maccio (2014) <https://ui.adsabs.harvard.edu/abs/2014MNRAS.441.3359D/abstract>`_
+- ``NFW_m200_c``, an NFW halo with the [:math:`z=0`] mass-concentration relation from `Dutton & Maccio (2014) <https://ui.adsabs.harvard.edu/abs/2014MNRAS.441.3359D/abstract>`_
     - ``f``: dark matter fraction [:math:`M_{200}` / total-stellar-mass]
 - ``Hernquist``
     - ``rhoc``: central density [:math:`M_\odot/\mathrm{km}^3`]

--- a/docs/getting_started/configuration.rst
+++ b/docs/getting_started/configuration.rst
@@ -83,7 +83,7 @@ This section lists the following attributes of the system::
       name:  ...          # name for your galaxy
       H:  ...             # Hubble parameter in km/s/Mpc (optional, default = 70)
 
-To model systems at redshifts :math:`z>0`, provide the angular diameter distance and the Hubble parameter at the appropriate redshift. These can be calculated using `astropy.cosmology` e.g. for :math:`z=2` in the Planck 2018 cosmology,
+To model systems at redshifts :math:`z>0`, provide the angular diameter distance and the Hubble parameter at the appropriate redshift. These can be calculated using `astropy.cosmology` e.g. for :math:`z=2` in the Planck 2018 cosmology::
 
   from astropy.cosmology import Planck18 as cosmo
   z = 2

--- a/docs/getting_started/configuration.rst
+++ b/docs/getting_started/configuration.rst
@@ -81,8 +81,14 @@ This section lists the following attributes of the system::
   system_attributes:
       distMPc: ...        # distance in MPc
       name:  ...          # name for your galaxy
+      H:  ...             # Hubble parameter in km/s/Mpc (optional, default = 70)
 
-Note: DYNAMITE assumes a value of :math:`H_0 = 70\;\mathrm{km/s/Mpc}` which is often used in the literature. Also, the system is assumed at zero redshift :math:`z=0`. An extension to different cosmologies and system redshifts may be implemented at a later point.
+To model systems at redshifts :math:`z>0`, provide the angular diameter distance and the Hubble parameter at the appropriate redshift. These can be calculated using `astropy.cosmology` e.g. for :math:`z=2` in the Planck 2018 cosmology,
+
+  from astropy.cosmology import Planck18 as cosmo
+  z = 2
+  H = cosmo.H(z)
+  distMPc = cosmo.H(z)
 
 ``system_components``
 =====================

--- a/docs/more_info/changelog.rst
+++ b/docs/more_info/changelog.rst
@@ -4,10 +4,10 @@
 Change Log
 ****************
 
+- Improvement: provide option to specify Hubble parameter in config file to allow modelling at :math:`z>0`. Default is :math:`H = 70\;\mathrm{km/s/Mpc}`.
 - Improvement: Calculate intrinsic masses in Python instead of legacy Fortran when using the Python NNLS solvers.
 - Improvement: Reconfirmed DYNAMITE compatibility with numpy 2.x.
 - Bugfix: The bar code now works with ``orblibs_in_parallel: False``.
-- Improvement: DYNAMITE now consistently uses :math:`H_0 = 70\;\mathrm{km/s/Mpc}`.
 - Improvement: Gauss Hermite kinematics' systematic errors `GH_sys_err` are now always applied throughout DYNAMITE.
 - Improvement: The new utility method ``Configuration.remove_projected_masses_file()`` deletes the projected masses file.
 - Improvement: Calculate projected masses in Python instead of legacy Fortran when using the Python NNLS solvers.

--- a/dynamite/config_reader.py
+++ b/dynamite/config_reader.py
@@ -7,6 +7,7 @@ import math
 import logging
 import importlib
 import yaml
+import numpy as np
 
 from datetime import datetime, timezone
 
@@ -198,8 +199,7 @@ class Configuration(object):
                           f'located at {dyn.__path__}')
 
         self.logger.debug('Global variables: ' \
-                          f'{const.GRAV_CONST_KM = }, {const.PARSEC_KM = }, ' \
-                          f'{const.RHO_CRIT = }.')
+                          f'{const.GRAV_CONST_KM = }, {const.PARSEC_KM = }.')
 
         legacy_dir = \
             os.path.realpath(os.path.dirname(__file__)+'/../legacy_fortran')
@@ -452,13 +452,16 @@ class Configuration(object):
                 logger.info('system_attributes...')
                 logger.debug(f'system_attributes: {tuple(value.keys())}')
                 # check here so system attributes are not set arbitrarily
-                if any(k not in ['distMPc', 'name'] for k in value):
-                    text = 'system_attributes can only be distMPc and name, '\
+                if any(k not in ['distMPc', 'name', 'H'] for k in value):
+                    text = 'system_attributes can only be distMPc, name and (optionally) H '\
                            f'not {list(value.keys())}.'
                     logger.error(text)
                     raise ValueError(text)
                 for other, data in value.items():
                     setattr(self.system, other, data)
+                if hasattr(self.system, 'H') == False:
+                    self.system.H = 70.
+                self.system.RHO_CRIT = (3.*(self.system.H * 1e-6/const.PARSEC_KM)**2)/(8.*np.pi*const.GRAV_CONST_KM)
 
             # add orbit library settings to Settings object
 

--- a/dynamite/constants.py
+++ b/dynamite/constants.py
@@ -1,10 +1,7 @@
 import numpy as np
 
-H0 = 70. # km/s/Mpc, used in Fortran
-
 GRAV_CONST_KM = 6.67428e-11*1.98892e30/1e9
 PARSEC_KM = 1.4959787068e8*(648.000e3/np.pi)
-RHO_CRIT = (3.*(H0 * 1e-6/PARSEC_KM)**2)/(8.*np.pi*GRAV_CONST_KM)
 
 weight_file = 'orbit_weights.ecsv'  # weights file
 p_masses_file = 'mass_aper.ecsv'  # projected masses file

--- a/dynamite/orblib.py
+++ b/dynamite/orblib.py
@@ -225,13 +225,13 @@ class LegacyOrbitLibrary(OrbitLibrary):
         text += f"{settngs['quad_nth']}\n"
         text += f"{settngs['quad_nph']}\n"
         text += f"{dm_specs}\n"
-        text += f"{dm_par_vals}"
+        text += f"{dm_par_vals}\n"
         if self.system.is_bar_disk_system():
             len_disk_pot = len(stars.disk_pot.data)
             header_string_pot = str(len_mge_pot + len_disk_pot) + " 1 " + str(len_mge_pot) + " " + str(len_disk_pot)
             len_disk_lum = len(stars.disk_lum.data)
             header_string_lum = str(len_mge_lum + len_disk_lum) + " 1 " + str(len_mge_lum) + " " + str(len_disk_lum)
-            text += f"\n{self.parset['omega']}"
+            text += f"{self.parset['omega']}\n"
             mge_pot = stars.mge_pot + stars.disk_pot
             mge_lum = stars.mge_lum + stars.disk_lum
         else:
@@ -239,6 +239,7 @@ class LegacyOrbitLibrary(OrbitLibrary):
             header_string_lum = str(len_mge_lum)
             mge_pot = stars.mge_pot
             mge_lum = stars.mge_lum
+        text += f"{self.system.H*1e-6}"
 
         # parameters_pot.in
         np.savetxt(path + 'parameters_pot.in',

--- a/dynamite/physical_system.py
+++ b/dynamite/physical_system.py
@@ -1187,7 +1187,7 @@ class NFW_m200_c(DarkComponent):
         stars = system.get_component_from_class(TriaxialVisibleComponent)
         M_stars_tot = stars.get_M_stars_tot(system.distMPc, parset)
         f = parset[f'f-{self.name}']
-        h = dyn.constants.H0 / 100
+        h = system.H / 100
         #total mass of dark matter
         MvDM = f * M_stars_tot
         #dutton&maccio2014 (https://arxiv.org/pdf/1402.7073.pdf) Eq. (8)
@@ -1372,58 +1372,6 @@ class GeneralisedNFW(DarkComponent):
         else:
             is_valid = True
         return is_valid
-
-    ## fixme: should actually derive (rhoc,rc) from (c,Mvir)
-    @staticmethod
-    def convert_parset(par):
-        '''
-        Returns
-        -------
-        rhoc : float
-            Scale density, unit : Msun/pc**3
-        rc : float
-            Scale radius, unit : pc
-        '''
-        Mvir = par['Mvir']
-        c = par['c']
-        gam = par['gam']
-
-        rho_crit = dyn.constants.RHO_CRIT * dyn.constants.PARSEC_KM ** 3
-
-        r200 = (3 * Mvir / (800 * np.pi * rho_crit))**(1.0 / 3.0)
-        rc = r200 / c
-
-        gamma1 = 3.0 - gam
-        hyp = special.hyp2f1(gamma1, gamma1, gamma1 + 1.0, -c)
-        rhoc = Mvir * gamma1 / (4.0 * np.pi * rc**3 * c**gamma1 * hyp)
-
-
-        return rhoc, rc, gam
-
-    @staticmethod
-    def potential(x, y, z, halo_pars):
-        '''
-        Returns
-        -------
-        psi : float
-            Scale density, unit : (km/s)^2
-        '''
-
-        # G = 4.3009172706e-3                        # pc/Msun⋅(km/s)**2
-        G = dyn.constants.GRAV_CONST_KM / dyn.constants.PARSEC_KM
-        rhoc, rc, gamma = halo_pars
-
-        x = np.asarray(x, dtype=float)
-        y = np.asarray(y, dtype=float)
-        z = np.asarray(z, dtype=float)
-
-        r = np.sqrt(x**2 + y**2 + z**2)
-
-        xi = r/(r + rc)
-        psi = ( 4 * np.pi * G * rhoc * rc**2 * (rc/r * xi**(3-gamma)/(3-gamma)
-                * special.hyp2f1(3-gamma,1,4-gamma,xi)
-                + (1 - xi**(3-gamma))/(2-gamma)))
-        return psi
 
     @staticmethod
     def density(x, y, z, halo_pars):

--- a/dynamite/physical_system.py
+++ b/dynamite/physical_system.py
@@ -1153,7 +1153,7 @@ class NFW(DarkComponent):
 
 
 class NFW_m200_c(DarkComponent):
-    """An NFW halo with m200-c relation from Dutton & Maccio 14
+    """An NFW halo with the z=0 m200-c relation from Dutton & Maccio 14
 
     The relation: log10(c200) = 0.905 - 0.101 * log10(M200/(1e12/h)).
     Component defined with parameter f [dm-fraction, M200/total-stellar-mass]

--- a/dynamite/plotter.py
+++ b/dynamite/plotter.py
@@ -1007,7 +1007,7 @@ class Plotter():
         #Input parameters: NFW dark matter concentration and fraction,
         #and stellar mass
 
-        rho_crit = constants.RHO_CRIT
+        rho_crit = self.system.RHO_CRIT
 
         rhoc = (200./3.)*rho_crit*cc**3/(np.log(1.+cc) - cc/(1.+cc))
         rc = (3./(800.*np.pi*rho_crit*cc**3)*dmfrac*mstars)**(1./3.)

--- a/legacy_fortran/iniparam_f.f90
+++ b/legacy_fortran/iniparam_f.f90
@@ -77,11 +77,10 @@ module initial_parameters
     ![http://physics.nist.gov/cgi-bin/cuu/Value?bg|search_for=newtonian]
 
     !           G = 1.33381d11 km^3/(s^2 Msun)
-    !  critical density rho_crit = 3H^2/8piG
     real(kind=dp), parameter, public :: &
         grav_const_km = 6.67428e-11_dp*1.98892e30_dp/1e9_dp, &
-        parsec_km = 1.4959787068d8*(648d3/pi_d), &
-        rho_crit = (3.0_dp*(7.0d-5/parsec_km)**2)/(8.0_dp*pi_d*grav_const_km)
+        parsec_km = 1.4959787068d8*(648d3/pi_d)
+    real(kind=dp), public :: rho_crit
 
     private ! default private
     public :: iniparam, iniparam_bar
@@ -92,7 +91,7 @@ contains
 
         character(len=256) :: infil
         real(kind=dp), dimension(:), allocatable :: surf_pc, sigobs_arcsec
-        real(kind=dp) :: distance, upsilon, softl_arcsec
+        real(kind=dp) :: distance, upsilon, softl_arcsec, H
         integer(kind=i4b) :: j
 
         print *, "Gravitational Constant in km^3/(s^2 Msun)", grav_const_km
@@ -149,9 +148,13 @@ contains
         read (unit=13, fmt=*) dm_profile_type, n_dmparam
         allocate (dmparam(n_dmparam))
         read (unit=13, fmt=*) dmparam(1:n_dmparam)
+        read (unit=13, fmt=*) H
 
         close (unit=13)
 
+        !  critical density rho_crit = 3H^2/8piG
+        rho_crit = (3.0_dp*(H/parsec_km)**2)/(8.0_dp*pi_d*grav_const_km)
+    
         ! apply dithering to the number of orbits
         Nener = Nener*orbit_dithering
         nI2 = nI2*orbit_dithering
@@ -200,7 +203,7 @@ contains
         real (kind=dp), dimension(:), allocatable :: surf_pc, sigobs_arcsec        ! (BT)
         real (kind=dp), dimension(:), allocatable :: surf_pc_d, sigobs_arcsec_d    ! (BT)
         real (kind=dp), dimension(:), allocatable :: surf_pc_b, sigobs_arcsec_b    ! (BT)
-        real(kind=dp) :: distance, upsilon, softl_arcsec
+        real(kind=dp) :: distance, upsilon, softl_arcsec, H
         integer(kind=i4b) :: j
 
         print *, "Gravitational Constant in km^3/(s^2 Msun)", grav_const_km
@@ -281,7 +284,12 @@ contains
         allocate (dmparam(n_dmparam))
         read (unit=13, fmt=*) dmparam(1:n_dmparam)
         read (unit=13, fmt=*) Omega   ! (BT) reading pattern speed
+        read (unit=13, fmt=*) H
+
         close (unit=13)
+
+        !  critical density rho_crit = 3H^2/8piG
+        rho_crit = (3.0_dp*(H/parsec_km)**2)/(8.0_dp*pi_d*grav_const_km)
 
         ! apply dithering to the number of orbits
         Nener = Nener*orbit_dithering


### PR DESCRIPTION
For z>0, the provided distance should be the angular diameter distance. All arcsec --> kpc conversions then follow as before. A Hubble parameter can now also be specified in the config file under `system`. This is appended to `parameters_lum/pot.in` to be passed into the orbit integrator.

Tested with `test_nnls.py` and `test_notebooks.sh`.

@maindlt - would appreciate if you could re-test and merge if successful. Note: this requires re-making the legacy fortran programs.

Adresses #228 and (re-addresses)#362.